### PR TITLE
refactor: Phase 2 - KissFFT backend (O(N log N))

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,15 +14,17 @@ FetchContent_Declare(
         kissfft_src
         GIT_REPOSITORY https://github.com/mborgerding/kissfft.git
         GIT_TAG        master
+        SOURCE_SUBDIR  "_none_"
 )
-FetchContent_GetProperties(kissfft_src)
-if(NOT kissfft_src_POPULATED)
-    FetchContent_Populate(kissfft_src)
-endif()
+FetchContent_MakeAvailable(kissfft_src)
 
 add_library(kissfft STATIC ${kissfft_src_SOURCE_DIR}/kiss_fft.c)
 target_include_directories(kissfft PUBLIC ${kissfft_src_SOURCE_DIR})
 set_target_properties(kissfft PROPERTIES LINKER_LANGUAGE C)
+target_compile_options(kissfft PRIVATE
+        $<$<C_COMPILER_ID:MSVC>:/wd4267>
+        $<$<C_COMPILER_ID:GNU,Clang>:-w>
+)
 
 set(DISSONANCE_SOURCES
         src/utils/WavParser.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,15 +4,11 @@ project(dissonance-core LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-option(BUILD_NODE_ADDON "Build the Node.js addon with CMake (node_api.h required)" OFF)
-option(BUILD_CLI "Build the CLI executable (requires WavGUI)" ON)
+option(BUILD_NODE_ADDON "Build the Node.js addon (requires node_api.h)" OFF)
+option(BUILD_CLI "Build the CLI executable" ON)
 
 set(DISSONANCE_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
 
-# -------------------------
-# KissFFT — fetched at configure time for CMake builds.
-# (node-gyp builds use vendor/kissfft/ directly via binding.gyp)
-# -------------------------
 include(FetchContent)
 FetchContent_Declare(
         kissfft_src
@@ -28,82 +24,56 @@ add_library(kissfft STATIC ${kissfft_src_SOURCE_DIR}/kiss_fft.c)
 target_include_directories(kissfft PUBLIC ${kissfft_src_SOURCE_DIR})
 set_target_properties(kissfft PROPERTIES LINKER_LANGUAGE C)
 
-set(DISSONANCE_AUDIO_SOURCES
+set(DISSONANCE_SOURCES
         src/utils/WavParser.cpp
-        src/audio/GainProcessor.cpp
         src/utils/WavUtils.cpp
+        src/audio/GainProcessor.cpp
         src/audio/WavProcessor.cpp
         src/audio/WindowFunctions.cpp
         src/audio/FFTProcessor.cpp
 )
 
-# -------------------------
-# Node.js addon (.node)
-# -------------------------
 if(BUILD_NODE_ADDON)
         add_library(dissonance_core SHARED
                 src/addon/addon.cpp
                 src/addon/AddonHelpers.cpp
-                ${DISSONANCE_AUDIO_SOURCES}
+                ${DISSONANCE_SOURCES}
         )
-
         target_include_directories(dissonance_core PRIVATE
                 ${DISSONANCE_INCLUDE_DIR}
                 ${CMAKE_SOURCE_DIR}/node_modules/node-addon-api
         )
-        target_link_libraries(dissonance_core PRIVATE kissfft)
-
-        # If you want CMake to find node_api.h, point NODE_INCLUDE_DIR to your Node headers, e.g.
-        # cmake -S . -B cmake-build -DBUILD_NODE_ADDON=ON -DNODE_INCLUDE_DIR="C:/Users/<you>/AppData/Local/node-gyp/Cache/<ver>/include/node"
         if(DEFINED NODE_INCLUDE_DIR)
                 target_include_directories(dissonance_core PRIVATE ${NODE_INCLUDE_DIR})
         endif()
-
-        set_target_properties(dissonance_core PROPERTIES
-                PREFIX ""
-                SUFFIX ".node"
-        )
+        target_link_libraries(dissonance_core PRIVATE kissfft)
+        set_target_properties(dissonance_core PROPERTIES PREFIX "" SUFFIX ".node")
 endif()
 
-# -------------------------
-# Standalone CLI executable
-# -------------------------
 if(BUILD_CLI)
         add_executable(dissonance.core
                 src/cli/main.cpp
                 src/cli/Commands.cpp
-                src/cli/WavGUI.cpp
-                ${DISSONANCE_AUDIO_SOURCES}
+                src/cli/ConsolePrinter.cpp
+                ${DISSONANCE_SOURCES}
         )
-
         target_include_directories(dissonance.core PRIVATE ${DISSONANCE_INCLUDE_DIR})
         target_link_libraries(dissonance.core PRIVATE kissfft)
-
         set_target_properties(dissonance.core PROPERTIES
                 RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
 endif()
 
-# -------------------------
-# Unit tests (GoogleTest)
-# -------------------------
 enable_testing()
-
 file(GLOB TEST_SOURCES tests/*.cpp)
 find_package(GTest QUIET)
 
 if(GTest_FOUND AND TEST_SOURCES)
-        add_executable(runTests
-                ${TEST_SOURCES}
-                ${DISSONANCE_AUDIO_SOURCES}
-        )
-
+        add_executable(runTests ${TEST_SOURCES} ${DISSONANCE_SOURCES})
         target_include_directories(runTests PRIVATE ${DISSONANCE_INCLUDE_DIR})
         target_link_libraries(runTests PRIVATE kissfft GTest::GTest GTest::Main)
-
         set_target_properties(runTests PROPERTIES
                 RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
-
         add_test(NAME runTests COMMAND runTests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 project(dissonance-core LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -10,10 +10,22 @@ option(BUILD_CLI "Build the CLI executable (requires WavGUI)" ON)
 set(DISSONANCE_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
 
 # -------------------------
-# KissFFT (vendored, plain C)
+# KissFFT — fetched at configure time for CMake builds.
+# (node-gyp builds use vendor/kissfft/ directly via binding.gyp)
 # -------------------------
-add_library(kissfft STATIC vendor/kissfft/kiss_fft.c)
-target_include_directories(kissfft PUBLIC vendor/kissfft)
+include(FetchContent)
+FetchContent_Declare(
+        kissfft_src
+        GIT_REPOSITORY https://github.com/mborgerding/kissfft.git
+        GIT_TAG        master
+)
+FetchContent_GetProperties(kissfft_src)
+if(NOT kissfft_src_POPULATED)
+    FetchContent_Populate(kissfft_src)
+endif()
+
+add_library(kissfft STATIC ${kissfft_src_SOURCE_DIR}/kiss_fft.c)
+target_include_directories(kissfft PUBLIC ${kissfft_src_SOURCE_DIR})
 set_target_properties(kissfft PROPERTIES LINKER_LANGUAGE C)
 
 set(DISSONANCE_AUDIO_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(dissonance-core LANGUAGES CXX)
+project(dissonance-core LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -8,6 +8,13 @@ option(BUILD_NODE_ADDON "Build the Node.js addon with CMake (node_api.h required
 option(BUILD_CLI "Build the CLI executable (requires WavGUI)" ON)
 
 set(DISSONANCE_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
+
+# -------------------------
+# KissFFT (vendored, plain C)
+# -------------------------
+add_library(kissfft STATIC vendor/kissfft/kiss_fft.c)
+target_include_directories(kissfft PUBLIC vendor/kissfft)
+set_target_properties(kissfft PROPERTIES LINKER_LANGUAGE C)
 
 set(DISSONANCE_AUDIO_SOURCES
         src/utils/WavParser.cpp
@@ -32,6 +39,7 @@ if(BUILD_NODE_ADDON)
                 ${DISSONANCE_INCLUDE_DIR}
                 ${CMAKE_SOURCE_DIR}/node_modules/node-addon-api
         )
+        target_link_libraries(dissonance_core PRIVATE kissfft)
 
         # If you want CMake to find node_api.h, point NODE_INCLUDE_DIR to your Node headers, e.g.
         # cmake -S . -B cmake-build -DBUILD_NODE_ADDON=ON -DNODE_INCLUDE_DIR="C:/Users/<you>/AppData/Local/node-gyp/Cache/<ver>/include/node"
@@ -57,6 +65,7 @@ if(BUILD_CLI)
         )
 
         target_include_directories(dissonance.core PRIVATE ${DISSONANCE_INCLUDE_DIR})
+        target_link_libraries(dissonance.core PRIVATE kissfft)
 
         set_target_properties(dissonance.core PROPERTIES
                 RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -78,11 +87,11 @@ if(GTest_FOUND AND TEST_SOURCES)
         )
 
         target_include_directories(runTests PRIVATE ${DISSONANCE_INCLUDE_DIR})
+        target_link_libraries(runTests PRIVATE kissfft GTest::GTest GTest::Main)
 
         set_target_properties(runTests PROPERTIES
                 RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
 
-        target_link_libraries(runTests PRIVATE GTest::GTest GTest::Main)
         add_test(NAME runTests COMMAND runTests)
 endif()

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,12 +10,14 @@
         "src/utils/WavUtils.cpp",
         "src/audio/WavProcessor.cpp",
         "src/audio/WindowFunctions.cpp",
-        "src/audio/FFTProcessor.cpp"
+        "src/audio/FFTProcessor.cpp",
+        "vendor/kissfft/kiss_fft.c"
       ],
       "include_dirs": [
         "<!(node -p \"require('node-addon-api').include\")",
         "<(module_root_dir)/node_modules/node-addon-api",
-        "<(module_root_dir)/include"
+        "<(module_root_dir)/include",
+        "<(module_root_dir)/vendor/kissfft"
       ],
       "dependencies": [
         "<!(node -p \"require('node-addon-api').gyp\")"

--- a/include/cli/Commands.hpp
+++ b/include/cli/Commands.hpp
@@ -7,5 +7,5 @@ class Commands {
     static void printUsage(const char *programName);
     static int handleInfo(const std::string &inputPath);
     static int handleProcess(const std::string &inputPath, int argc, char **argv, int startIdx);
-    static int handleFft(const std::string &inputPath);
+    static int handleFft(const std::string &inputPath, int argc, char **argv, int startIdx);
 };

--- a/include/cli/ConsolePrinter.hpp
+++ b/include/cli/ConsolePrinter.hpp
@@ -10,9 +10,9 @@ extern const std::array<std::string, 5> COLORS;
 
 void printField(const std::string &label, const std::string &value);
 
-class GUI {
+class ConsolePrinter {
   public:
-    explicit GUI(const std::string &filename);
+    explicit ConsolePrinter(const std::string &filename);
     [[nodiscard]] bool isValid() const { return valid; }
     void printMetadata() const;
     void printOtherChunks() const;

--- a/src/audio/FFTProcessor.cpp
+++ b/src/audio/FFTProcessor.cpp
@@ -1,8 +1,22 @@
 #include "audio/FFTProcessor.hpp"
 #include "core/Errors.hpp"
 
-#include <algorithm>
-#include <cmath>
+#include <kiss_fft.h>
+
+namespace {
+
+struct KissCfg {
+    kiss_fft_cfg cfg;
+    KissCfg(int n, int inverse) : cfg(kiss_fft_alloc(n, inverse, nullptr, nullptr)) {
+        if (!cfg)
+            throw dissonance::DspError("Failed to allocate KissFFT config");
+    }
+    ~KissCfg() { kiss_fft_free(cfg); }
+    KissCfg(const KissCfg &) = delete;
+    KissCfg &operator=(const KissCfg &) = delete;
+};
+
+} // namespace
 
 namespace fft {
 
@@ -10,44 +24,49 @@ std::vector<std::complex<double>> transform(const std::vector<double> &input) {
     if (input.empty())
         throw dissonance::DspError("FFT input cannot be empty");
 
-    const size_t N = input.size();
-    std::vector<std::complex<double>> output(N);
+    const int N = static_cast<int>(input.size());
+    KissCfg cfg(N, 0);
 
-    const double twoPiOverN = 2.0 * std::acos(-1.0) / static_cast<double>(N);
-    for (size_t k = 0; k < N; ++k) {
-        std::complex<double> sum{0.0, 0.0};
-        for (size_t n = 0; n < N; ++n) {
-            const double angle = twoPiOverN * static_cast<double>(k * n);
-            sum += input[n] * std::complex<double>{std::cos(angle), -std::sin(angle)};
-        }
-        output[k] = sum;
+    std::vector<kiss_fft_cpx> in(N), out(N);
+    for (int i = 0; i < N; ++i) {
+        in[i].r = static_cast<float>(input[i]);
+        in[i].i = 0.0f;
     }
-    return output;
+
+    kiss_fft(cfg.cfg, in.data(), out.data());
+
+    std::vector<std::complex<double>> result(N);
+    for (int i = 0; i < N; ++i)
+        result[i] = {static_cast<double>(out[i].r), static_cast<double>(out[i].i)};
+    return result;
 }
 
 std::vector<double> inverse(const std::vector<std::complex<double>> &spectrum) {
     if (spectrum.empty())
         throw dissonance::DspError("iFFT input cannot be empty");
 
-    const size_t N = spectrum.size();
-    std::vector<double> output(N);
+    const int N = static_cast<int>(spectrum.size());
+    KissCfg cfg(N, 1);
 
-    const double twoPiOverN = 2.0 * std::acos(-1.0) / static_cast<double>(N);
-    for (size_t n = 0; n < N; ++n) {
-        std::complex<double> sum{0.0, 0.0};
-        for (size_t k = 0; k < N; ++k) {
-            const double angle = twoPiOverN * static_cast<double>(k * n);
-            sum += spectrum[k] * std::complex<double>{std::cos(angle), std::sin(angle)};
-        }
-        output[n] = sum.real() / static_cast<double>(N);
+    std::vector<kiss_fft_cpx> in(N), out(N);
+    for (int i = 0; i < N; ++i) {
+        in[i].r = static_cast<float>(spectrum[i].real());
+        in[i].i = static_cast<float>(spectrum[i].imag());
     }
-    return output;
+
+    kiss_fft(cfg.cfg, in.data(), out.data());
+
+    const double scale = 1.0 / static_cast<double>(N);
+    std::vector<double> result(N);
+    for (int i = 0; i < N; ++i)
+        result[i] = static_cast<double>(out[i].r) * scale;
+    return result;
 }
 
 std::vector<double> magnitude(const std::vector<std::complex<double>> &spectrum) {
     std::vector<double> mags(spectrum.size());
-    std::transform(spectrum.begin(), spectrum.end(), mags.begin(),
-                   [](const std::complex<double> &v) { return std::abs(v); });
+    for (size_t i = 0; i < spectrum.size(); ++i)
+        mags[i] = std::abs(spectrum[i]);
     return mags;
 }
 

--- a/src/cli/Commands.cpp
+++ b/src/cli/Commands.cpp
@@ -15,7 +15,11 @@ void Commands::printUsage(const char *programName) {
               << "Commands:\n"
               << "  info          Print WAV file metadata and waveform\n"
               << "  process       Apply gain and spectral processing\n"
-              << "  fft           Analyze FFT spectrum of first block\n"
+              << "  fft           Analyze FFT spectrum of a 512-frame block\n"
+              << "\nOptions for 'fft':\n"
+              << "  --offset <seconds>  Start offset into the file (default: 0)\n"
+              << "  --bins <n>          Number of frequency bins to display (default: 16)\n"
+              << "  --full              Average spectrum across entire file (Welch's method)\n"
               << "\nOptions for 'process':\n"
               << "  --gain <value>      Apply gain (default: 0.8)\n"
               << "  --output <path>     Output file path (default: <input>-processed.wav)\n"
@@ -64,49 +68,104 @@ int Commands::handleProcess(const std::string &inputPath, int argc, char **argv,
     return EXIT_SUCCESS;
 }
 
-int Commands::handleFft(const std::string &inputPath) {
-    std::ifstream file(inputPath, std::ios::binary);
-    if (!file.is_open()) {
-        throw dissonance::WavFormatError("Failed to open file: " + inputPath);
+int Commands::handleFft(const std::string &inputPath, int argc, char **argv, int startIdx) {
+    double offsetSecs = 0.0;
+    size_t topBins = 16;
+    bool fullFile = false;
+
+    for (int i = startIdx; i < argc; ++i) {
+        if (std::string(argv[i]) == "--offset" && i + 1 < argc)
+            offsetSecs = std::stod(argv[++i]);
+        else if (std::string(argv[i]) == "--bins" && i + 1 < argc)
+            topBins = static_cast<size_t>(std::stoul(argv[++i]));
+        else if (std::string(argv[i]) == "--full")
+            fullFile = true;
     }
+
+    std::ifstream file(inputPath, std::ios::binary);
+    if (!file.is_open())
+        throw dissonance::WavFormatError("Failed to open file: " + inputPath);
     Parser parser = Parser::fromFile(file);
     file.close();
 
     const auto &samples = parser.getAudioData();
     const uint16_t numChannels = parser.getNumChannels();
+    const uint32_t sampleRate = parser.getSampleRate();
     const size_t totalFrames = samples.size() / numChannels;
-    const size_t framesToProcess = std::min<size_t>(totalFrames, 512);
 
-    if (framesToProcess < 2) {
-        throw dissonance::DspError("Not enough samples for FFT analysis");
-    }
+    constexpr size_t frameSize = 512;
+    constexpr size_t hopSize = 256;
 
-    const std::vector<double> win = window::generate(window::Type::Hann, framesToProcess);
+    const std::vector<double> win = window::generate(window::Type::Hann, frameSize);
 
     std::cout << "\n=== FFT Analysis ===\n";
     printField("Channels", std::to_string(numChannels));
-    printField("Sample rate", std::to_string(parser.getSampleRate()) + " Hz");
-    printField("Frames analyzed", std::to_string(framesToProcess));
-    std::cout << "\nFrequency resolution: "
-              << (static_cast<double>(parser.getSampleRate()) / framesToProcess) << " Hz/bin\n\n";
+    printField("Sample rate", std::to_string(sampleRate) + " Hz");
 
-    std::vector<float> blockF(framesToProcess);
-    for (size_t i = 0; i < framesToProcess; ++i)
-        blockF[i] = samples[i * numChannels];
+    std::vector<double> accumulated(frameSize, 0.0);
+    size_t windowCount = 0;
 
-    window::apply(blockF, win);
+    if (fullFile) {
+        if (totalFrames < frameSize)
+            throw dissonance::DspError("File too short for FFT analysis");
 
-    std::vector<double> blockD(blockF.begin(), blockF.end());
-    auto spectrum = fft::transform(blockD);
-    auto magnitudes = fft::magnitude(spectrum);
+        printField("Mode", "full file (averaged periodogram)");
+        printField("Window size", std::to_string(frameSize) + " frames");
+        printField("Hop size", std::to_string(hopSize) + " frames");
 
-    std::cout << "Top 16 frequency bins:\n";
+        for (size_t offset = 0; offset + frameSize <= totalFrames; offset += hopSize) {
+            std::vector<float> blockF(frameSize);
+            for (size_t i = 0; i < frameSize; ++i)
+                blockF[i] = samples[(offset + i) * numChannels];
+
+            window::apply(blockF, win);
+
+            std::vector<double> blockD(blockF.begin(), blockF.end());
+            auto mags = fft::magnitude(fft::transform(blockD));
+
+            for (size_t k = 0; k < frameSize; ++k)
+                accumulated[k] += mags[k];
+            ++windowCount;
+        }
+
+        printField("Windows averaged", std::to_string(windowCount));
+    } else {
+        const size_t offsetFrames =
+            std::min<size_t>(static_cast<size_t>(offsetSecs * sampleRate), totalFrames);
+        const size_t framesAvailable = totalFrames - offsetFrames;
+
+        if (framesAvailable < 2)
+            throw dissonance::DspError("Not enough samples for FFT analysis at this offset");
+
+        const size_t framesToProcess = std::min<size_t>(framesAvailable, frameSize);
+        printField("Offset",
+                   std::to_string(offsetSecs) + " s (frame " + std::to_string(offsetFrames) + ")");
+        printField("Frames analyzed", std::to_string(framesToProcess));
+
+        std::vector<float> blockF(framesToProcess);
+        for (size_t i = 0; i < framesToProcess; ++i)
+            blockF[i] = samples[(offsetFrames + i) * numChannels];
+
+        window::apply(blockF, win);
+
+        std::vector<double> blockD(blockF.begin(), blockF.end());
+        accumulated = fft::magnitude(fft::transform(blockD));
+        accumulated.resize(frameSize, 0.0);
+        windowCount = 1;
+    }
+
+    std::cout << "\nFrequency resolution: " << (static_cast<double>(sampleRate) / frameSize)
+              << " Hz/bin\n\n";
+
+    const size_t displayBins = std::min(topBins, frameSize / 2);
+    std::cout << "Top " << displayBins << " frequency bins:\n";
     std::cout << "Bin\tFreq (Hz)\tMagnitude\n";
     std::cout << "---\t---------\t---------\n";
 
-    for (size_t i = 0; i < std::min<size_t>(16, magnitudes.size() / 2); ++i) {
-        double freq = (static_cast<double>(i) * parser.getSampleRate()) / framesToProcess;
-        std::cout << i << "\t" << freq << "\t\t" << magnitudes[i] << "\n";
+    for (size_t i = 0; i < displayBins; ++i) {
+        double freq = (static_cast<double>(i) * sampleRate) / frameSize;
+        double mag = accumulated[i] / static_cast<double>(windowCount);
+        std::cout << i << "\t" << freq << "\t\t" << mag << "\n";
     }
 
     return EXIT_SUCCESS;

--- a/src/cli/Commands.cpp
+++ b/src/cli/Commands.cpp
@@ -1,5 +1,5 @@
 #include "cli/Commands.hpp"
-#include "cli/WavGUI.hpp"
+#include "cli/ConsolePrinter.hpp"
 #include "audio/WavProcessor.hpp"
 #include "audio/FFTProcessor.hpp"
 #include "audio/WindowFunctions.hpp"
@@ -30,14 +30,14 @@ void Commands::printUsage(const char *programName) {
 }
 
 int Commands::handleInfo(const std::string &inputPath) {
-    auto gui = std::make_shared<GUI>(inputPath);
-    if (gui->isValid()) {
+    auto printer = std::make_shared<ConsolePrinter>(inputPath);
+    if (printer->isValid()) {
         std::cout << "=== WAV File Information ===\n";
-        gui->printMetadata();
+        printer->printMetadata();
         std::cout << "\n=== Metadata Chunks ===\n";
-        gui->printOtherChunks();
+        printer->printOtherChunks();
         std::cout << "\n=== Waveform ===\n";
-        gui->printWaveform();
+        printer->printWaveform();
         return EXIT_SUCCESS;
     }
     throw dissonance::WavFormatError("WAV file invalid.");

--- a/src/cli/ConsolePrinter.cpp
+++ b/src/cli/ConsolePrinter.cpp
@@ -1,4 +1,4 @@
-#include "cli/WavGUI.hpp"
+#include "cli/ConsolePrinter.hpp"
 #include "utils/WavUtils.hpp"
 #include "core/Errors.hpp"
 
@@ -19,13 +19,13 @@ void printField(const std::string &label, const std::string &value) {
     }
 }
 
-GUI::GUI(const std::string &filename)
+ConsolePrinter::ConsolePrinter(const std::string &filename)
     : processed(processWavFile(filename)), valid(true), filename(filename) {
     std::cout << COLORS[0] << "Opening file: " << COLORS[3] << filename << COLORS[4] << std::endl;
     std::cout << COLORS[3] << "File opened successfully" << COLORS[4] << std::endl;
 }
 
-void GUI::printMetadata() const {
+void ConsolePrinter::printMetadata() const {
     if (!valid) {
         throw dissonance::WavFormatError("Failed to read file data");
     }
@@ -43,7 +43,7 @@ void GUI::printMetadata() const {
     }
 }
 
-void GUI::printWaveform() const {
+void ConsolePrinter::printWaveform() const {
     const std::string wave = renderWaveformASCII(processed.originalSamples);
     for (const char ch : wave) {
         if (ch == '|') {
@@ -54,7 +54,7 @@ void GUI::printWaveform() const {
     }
 }
 
-void GUI::printOtherChunks() const {
+void ConsolePrinter::printOtherChunks() const {
     if (!valid) {
         throw dissonance::WavFormatError("Failed to read other chunks");
     }
@@ -67,7 +67,7 @@ void GUI::printOtherChunks() const {
     }
 }
 
-void GUI::printListChunk(const std::vector<char> &value) const {
+void ConsolePrinter::printListChunk(const std::vector<char> &value) const {
     std::cout << std::endl << COLORS[3] << "MetaData:" << COLORS[4] << std::endl;
     const ListTags tags = parseListChunk(value);
 
@@ -80,7 +80,7 @@ void GUI::printListChunk(const std::vector<char> &value) const {
     printField("Copyright", tags.copyright);
 }
 
-void GUI::printGenericChunk(const std::string &key, const std::vector<char> &value) {
+void ConsolePrinter::printGenericChunk(const std::string &key, const std::vector<char> &value) {
     std::cout << "Chunk " << key << " data:" << std::endl;
     for (size_t i = 0; i < value.size(); ++i) {
         const char ch = value[i];

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
         }
 
         if (command == "fft") {
-            return Commands::handleFft(inputPath);
+            return Commands::handleFft(inputPath, argc, argv, 3);
         }
 
         std::cerr << "Unknown command: " << command << "\n";

--- a/vendor/kissfft/_kiss_fft_guts.h
+++ b/vendor/kissfft/_kiss_fft_guts.h
@@ -1,0 +1,189 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+/* kiss_fft.h
+   defines kiss_fft_scalar as either short or a float type
+   and defines
+   typedef struct { kiss_fft_scalar r; kiss_fft_scalar i; }kiss_fft_cpx; */
+
+#ifndef _kiss_fft_guts_h
+#define _kiss_fft_guts_h
+
+#include "kiss_fft.h"
+#include "kiss_fft_log.h"
+#include <limits.h>
+
+#define MAXFACTORS 32
+/* e.g. an fft of length 128 has 4 factors
+ as far as kissfft is concerned
+ 4*4*4*2
+ */
+
+struct kiss_fft_state{
+    int nfft;
+    int inverse;
+    int factors[2*MAXFACTORS];
+    kiss_fft_cpx twiddles[1];
+};
+
+/*
+  Explanation of macros dealing with complex math:
+
+   C_MUL(m,a,b)         : m = a*b
+   C_FIXDIV( c , div )  : if a fixed point impl., c /= div. noop otherwise
+   C_SUB( res, a,b)     : res = a - b
+   C_SUBFROM( res , a)  : res -= a
+   C_ADDTO( res , a)    : res += a
+ * */
+#ifdef FIXED_POINT
+#include <stdint.h>
+#if (FIXED_POINT==32)
+# define FRACBITS 31
+# define SAMPPROD int64_t
+#define SAMP_MAX INT32_MAX
+#define SAMP_MIN INT32_MIN
+#else
+# define FRACBITS 15
+# define SAMPPROD int32_t
+#define SAMP_MAX INT16_MAX
+#define SAMP_MIN INT16_MIN
+#endif
+
+#if defined(CHECK_OVERFLOW)
+#  define CHECK_OVERFLOW_OP(a,op,b)  \
+    if ( (SAMPPROD)(a) op (SAMPPROD)(b) > SAMP_MAX || (SAMPPROD)(a) op (SAMPPROD)(b) < SAMP_MIN ) { \
+        KISS_FFT_WARNING("overflow (%d " #op" %d) = %ld", (a),(b),(SAMPPROD)(a) op (SAMPPROD)(b)); }
+#endif
+
+
+#   define smul(a,b) ( (SAMPPROD)(a)*(b) )
+#   define sround( x )  (kiss_fft_scalar)( ( (x) + (1<<(FRACBITS-1)) ) >> FRACBITS )
+
+#   define S_MUL(a,b) sround( smul(a,b) )
+
+#   define C_MUL(m,a,b) \
+      do{ (m).r = sround( smul((a).r,(b).r) - smul((a).i,(b).i) ); \
+          (m).i = sround( smul((a).r,(b).i) + smul((a).i,(b).r) ); }while(0)
+
+#   define DIVSCALAR(x,k) \
+    (x) = sround( smul(  x, SAMP_MAX/k ) )
+
+#   define C_FIXDIV(c,div) \
+    do {    DIVSCALAR( (c).r , div);  \
+        DIVSCALAR( (c).i  , div); }while (0)
+
+#   define C_MULBYSCALAR( c, s ) \
+    do{ (c).r =  sround( smul( (c).r , s ) ) ;\
+        (c).i =  sround( smul( (c).i , s ) ) ; }while(0)
+
+#else  /* not FIXED_POINT*/
+
+#   define S_MUL(a,b) ( (a)*(b) )
+#define C_MUL(m,a,b) \
+    do{ (m).r = (a).r*(b).r - (a).i*(b).i;\
+        (m).i = (a).r*(b).i + (a).i*(b).r; }while(0)
+#   define C_FIXDIV(c,div) /* NOOP */
+#   define C_MULBYSCALAR( c, s ) \
+    do{ (c).r *= (s);\
+        (c).i *= (s); }while(0)
+#endif
+
+#ifndef CHECK_OVERFLOW_OP
+#  define CHECK_OVERFLOW_OP(a,op,b) /* noop */
+#endif
+
+#define  C_ADD( res, a,b)\
+    do { \
+        CHECK_OVERFLOW_OP((a).r,+,(b).r)\
+        CHECK_OVERFLOW_OP((a).i,+,(b).i)\
+        (res).r=(a).r+(b).r;  (res).i=(a).i+(b).i; \
+    }while(0)
+#define  C_SUB( res, a,b)\
+    do { \
+        CHECK_OVERFLOW_OP((a).r,-,(b).r)\
+        CHECK_OVERFLOW_OP((a).i,-,(b).i)\
+        (res).r=(a).r-(b).r;  (res).i=(a).i-(b).i; \
+    }while(0)
+#define C_ADDTO( res , a)\
+    do { \
+        CHECK_OVERFLOW_OP((res).r,+,(a).r)\
+        CHECK_OVERFLOW_OP((res).i,+,(a).i)\
+        (res).r += (a).r;  (res).i += (a).i;\
+    }while(0)
+
+#define C_SUBFROM( res , a)\
+    do {\
+        CHECK_OVERFLOW_OP((res).r,-,(a).r)\
+        CHECK_OVERFLOW_OP((res).i,-,(a).i)\
+        (res).r -= (a).r;  (res).i -= (a).i; \
+    }while(0)
+
+
+#ifdef FIXED_POINT
+#  define KISS_FFT_COS(phase)  floor(.5+SAMP_MAX * cos (phase))
+#  define KISS_FFT_SIN(phase)  floor(.5+SAMP_MAX * sin (phase))
+#  define HALF_OF(x) ((x)>>1)
+#elif defined(USE_SIMD)
+#if defined(HAVE_LASX)
+#define KISS_FFT_COS(phase) ({ \
+    float __cos_val = cosf(phase); \
+    (__m256)(__lasx_xvldrepl_w(&__cos_val, 0)); \
+})
+#define KISS_FFT_SIN(phase) ({ \
+    float __sin_val = sinf(phase); \
+    (__m256)(__lasx_xvldrepl_w(&__sin_val, 0)); \
+})
+#define HALF_OF(x) ((x) * (__m256)(__lasx_xvreplgr2vr_w(0x3F000000))) // 0.5f
+#elif defined(HAVE_LSX)
+#define KISS_FFT_COS(phase) ({ \
+    float __cos_val = cosf(phase); \
+    (__m128)(__lsx_vldrepl_w(&__cos_val, 0)); \
+})
+#define KISS_FFT_SIN(phase) ({ \
+    float __sin_val = sinf(phase); \
+    (__m128)(__lsx_vldrepl_w(&__sin_val, 0)); \
+})
+#define HALF_OF(x) ((x) * (__m128)(__lsx_vreplgr2vr_w(0x3F000000))) // 0.5f
+#else
+#  define KISS_FFT_COS(phase) _mm_set1_ps( cos(phase) )
+#  define KISS_FFT_SIN(phase) _mm_set1_ps( sin(phase) )
+#  define HALF_OF(x) ((x)*_mm_set1_ps(.5))
+#endif
+#else
+#  define KISS_FFT_COS(phase) (kiss_fft_scalar) cos(phase)
+#  define KISS_FFT_SIN(phase) (kiss_fft_scalar) sin(phase)
+#  define HALF_OF(x) ((x)*((kiss_fft_scalar).5))
+#endif
+
+#define  kf_cexp(x,phase) \
+    do{ \
+        (x)->r = KISS_FFT_COS(phase);\
+        (x)->i = KISS_FFT_SIN(phase);\
+    }while(0)
+
+
+/* a debugging function */
+#define pcpx(c)\
+    KISS_FFT_DEBUG("%g + %gi\n",(double)((c)->r),(double)((c)->i))
+
+
+#ifdef KISS_FFT_USE_ALLOCA
+// define this to allow use of alloca instead of malloc for temporary buffers
+// Temporary buffers are used in two case:
+// 1. FFT sizes that have "bad" factors. i.e. not 2,3 and 5
+// 2. "in-place" FFTs.  Notice the quotes, since kissfft does not really do an in-place transform.
+#include <alloca.h>
+#define  KISS_FFT_TMP_ALLOC(nbytes) alloca(nbytes)
+#define  KISS_FFT_TMP_FREE(ptr)
+#else
+#define  KISS_FFT_TMP_ALLOC(nbytes) KISS_FFT_MALLOC(nbytes)
+#define  KISS_FFT_TMP_FREE(ptr) KISS_FFT_FREE(ptr)
+#endif
+
+#endif /* _kiss_fft_guts_h */
+

--- a/vendor/kissfft/kiss_fft.c
+++ b/vendor/kissfft/kiss_fft.c
@@ -1,0 +1,424 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#include <stdint.h>
+#include "_kiss_fft_guts.h"
+/* The guts header contains all the multiplication and addition macros that are defined for
+ fixed or floating point complex numbers.  It also delares the kf_ internal functions.
+ */
+
+static void kf_bfly2(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m
+        )
+{
+    kiss_fft_cpx * Fout2;
+    kiss_fft_cpx * tw1 = st->twiddles;
+    kiss_fft_cpx t;
+    Fout2 = Fout + m;
+    do{
+        C_FIXDIV(*Fout,2); C_FIXDIV(*Fout2,2);
+
+        C_MUL (t,  *Fout2 , *tw1);
+        tw1 += fstride;
+        C_SUB( *Fout2 ,  *Fout , t );
+        C_ADDTO( *Fout ,  t );
+        ++Fout2;
+        ++Fout;
+    }while (--m);
+}
+
+static void kf_bfly4(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        const size_t m
+        )
+{
+    kiss_fft_cpx *tw1,*tw2,*tw3;
+    kiss_fft_cpx scratch[6];
+    size_t k=m;
+    const size_t m2=2*m;
+    const size_t m3=3*m;
+
+
+    tw3 = tw2 = tw1 = st->twiddles;
+
+    do {
+        C_FIXDIV(*Fout,4); C_FIXDIV(Fout[m],4); C_FIXDIV(Fout[m2],4); C_FIXDIV(Fout[m3],4);
+
+        C_MUL(scratch[0],Fout[m] , *tw1 );
+        C_MUL(scratch[1],Fout[m2] , *tw2 );
+        C_MUL(scratch[2],Fout[m3] , *tw3 );
+
+        C_SUB( scratch[5] , *Fout, scratch[1] );
+        C_ADDTO(*Fout, scratch[1]);
+        C_ADD( scratch[3] , scratch[0] , scratch[2] );
+        C_SUB( scratch[4] , scratch[0] , scratch[2] );
+        C_SUB( Fout[m2], *Fout, scratch[3] );
+        tw1 += fstride;
+        tw2 += fstride*2;
+        tw3 += fstride*3;
+        C_ADDTO( *Fout , scratch[3] );
+
+        if(st->inverse) {
+            Fout[m].r = scratch[5].r - scratch[4].i;
+            Fout[m].i = scratch[5].i + scratch[4].r;
+            Fout[m3].r = scratch[5].r + scratch[4].i;
+            Fout[m3].i = scratch[5].i - scratch[4].r;
+        }else{
+            Fout[m].r = scratch[5].r + scratch[4].i;
+            Fout[m].i = scratch[5].i - scratch[4].r;
+            Fout[m3].r = scratch[5].r - scratch[4].i;
+            Fout[m3].i = scratch[5].i + scratch[4].r;
+        }
+        ++Fout;
+    }while(--k);
+}
+
+static void kf_bfly3(
+         kiss_fft_cpx * Fout,
+         const size_t fstride,
+         const kiss_fft_cfg st,
+         size_t m
+         )
+{
+     size_t k=m;
+     const size_t m2 = 2*m;
+     kiss_fft_cpx *tw1,*tw2;
+     kiss_fft_cpx scratch[5];
+     kiss_fft_cpx epi3;
+     epi3 = st->twiddles[fstride*m];
+
+     tw1=tw2=st->twiddles;
+
+     do{
+         C_FIXDIV(*Fout,3); C_FIXDIV(Fout[m],3); C_FIXDIV(Fout[m2],3);
+
+         C_MUL(scratch[1],Fout[m] , *tw1);
+         C_MUL(scratch[2],Fout[m2] , *tw2);
+
+         C_ADD(scratch[3],scratch[1],scratch[2]);
+         C_SUB(scratch[0],scratch[1],scratch[2]);
+         tw1 += fstride;
+         tw2 += fstride*2;
+
+         Fout[m].r = Fout->r - HALF_OF(scratch[3].r);
+         Fout[m].i = Fout->i - HALF_OF(scratch[3].i);
+
+         C_MULBYSCALAR( scratch[0] , epi3.i );
+
+         C_ADDTO(*Fout,scratch[3]);
+
+         Fout[m2].r = Fout[m].r + scratch[0].i;
+         Fout[m2].i = Fout[m].i - scratch[0].r;
+
+         Fout[m].r -= scratch[0].i;
+         Fout[m].i += scratch[0].r;
+
+         ++Fout;
+     }while(--k);
+}
+
+static void kf_bfly5(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m
+        )
+{
+    kiss_fft_cpx *Fout0,*Fout1,*Fout2,*Fout3,*Fout4;
+    int u;
+    kiss_fft_cpx scratch[13];
+    kiss_fft_cpx * twiddles = st->twiddles;
+    kiss_fft_cpx *tw;
+    kiss_fft_cpx ya,yb;
+    ya = twiddles[fstride*m];
+    yb = twiddles[fstride*2*m];
+
+    Fout0=Fout;
+    Fout1=Fout0+m;
+    Fout2=Fout0+2*m;
+    Fout3=Fout0+3*m;
+    Fout4=Fout0+4*m;
+
+    tw=st->twiddles;
+    for ( u=0; u<m; ++u ) {
+        C_FIXDIV( *Fout0,5); C_FIXDIV( *Fout1,5); C_FIXDIV( *Fout2,5); C_FIXDIV( *Fout3,5); C_FIXDIV( *Fout4,5);
+        scratch[0] = *Fout0;
+
+        C_MUL(scratch[1] ,*Fout1, tw[u*fstride]);
+        C_MUL(scratch[2] ,*Fout2, tw[2*u*fstride]);
+        C_MUL(scratch[3] ,*Fout3, tw[3*u*fstride]);
+        C_MUL(scratch[4] ,*Fout4, tw[4*u*fstride]);
+
+        C_ADD( scratch[7],scratch[1],scratch[4]);
+        C_SUB( scratch[10],scratch[1],scratch[4]);
+        C_ADD( scratch[8],scratch[2],scratch[3]);
+        C_SUB( scratch[9],scratch[2],scratch[3]);
+
+        Fout0->r += scratch[7].r + scratch[8].r;
+        Fout0->i += scratch[7].i + scratch[8].i;
+
+        scratch[5].r = scratch[0].r + S_MUL(scratch[7].r,ya.r) + S_MUL(scratch[8].r,yb.r);
+        scratch[5].i = scratch[0].i + S_MUL(scratch[7].i,ya.r) + S_MUL(scratch[8].i,yb.r);
+
+        scratch[6].r =  S_MUL(scratch[10].i,ya.i) + S_MUL(scratch[9].i,yb.i);
+        scratch[6].i = -S_MUL(scratch[10].r,ya.i) - S_MUL(scratch[9].r,yb.i);
+
+        C_SUB(*Fout1,scratch[5],scratch[6]);
+        C_ADD(*Fout4,scratch[5],scratch[6]);
+
+        scratch[11].r = scratch[0].r + S_MUL(scratch[7].r,yb.r) + S_MUL(scratch[8].r,ya.r);
+        scratch[11].i = scratch[0].i + S_MUL(scratch[7].i,yb.r) + S_MUL(scratch[8].i,ya.r);
+        scratch[12].r = - S_MUL(scratch[10].i,yb.i) + S_MUL(scratch[9].i,ya.i);
+        scratch[12].i = S_MUL(scratch[10].r,yb.i) - S_MUL(scratch[9].r,ya.i);
+
+        C_ADD(*Fout2,scratch[11],scratch[12]);
+        C_SUB(*Fout3,scratch[11],scratch[12]);
+
+        ++Fout0;++Fout1;++Fout2;++Fout3;++Fout4;
+    }
+}
+
+/* perform the butterfly for one stage of a mixed radix FFT */
+static void kf_bfly_generic(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m,
+        int p
+        )
+{
+    int u,k,q1,q;
+    kiss_fft_cpx * twiddles = st->twiddles;
+    kiss_fft_cpx t;
+    int Norig = st->nfft;
+
+    kiss_fft_cpx * scratch = (kiss_fft_cpx*)KISS_FFT_TMP_ALLOC(sizeof(kiss_fft_cpx)*p);
+    if (scratch == NULL){
+        KISS_FFT_ERROR("Memory allocation failed.");
+        return;
+    }
+
+    for ( u=0; u<m; ++u ) {
+        k=u;
+        for ( q1=0 ; q1<p ; ++q1 ) {
+            scratch[q1] = Fout[ k  ];
+            C_FIXDIV(scratch[q1],p);
+            k += m;
+        }
+
+        k=u;
+        for ( q1=0 ; q1<p ; ++q1 ) {
+            int twidx=0;
+            Fout[ k ] = scratch[0];
+            for (q=1;q<p;++q ) {
+                twidx += fstride * k;
+                if (twidx>=Norig) twidx-=Norig;
+                C_MUL(t,scratch[q] , twiddles[twidx] );
+                C_ADDTO( Fout[ k ] ,t);
+            }
+            k += m;
+        }
+    }
+    KISS_FFT_TMP_FREE(scratch);
+}
+
+static
+void kf_work(
+        kiss_fft_cpx * Fout,
+        const kiss_fft_cpx * f,
+        const size_t fstride,
+        int in_stride,
+        int * factors,
+        const kiss_fft_cfg st
+        )
+{
+    kiss_fft_cpx * Fout_beg=Fout;
+    const int p=*factors++; /* the radix  */
+    const int m=*factors++; /* stage's fft length/p */
+    const kiss_fft_cpx * Fout_end = Fout + p*m;
+
+#ifdef _OPENMP
+    // use openmp extensions at the
+    // top-level (not recursive)
+    if (fstride==1 && p<=5 && m!=1)
+    {
+        int k;
+
+        // execute the p different work units in different threads
+#       pragma omp parallel for
+        for (k=0;k<p;++k)
+            kf_work( Fout +k*m, f+ fstride*in_stride*k,fstride*p,in_stride,factors,st);
+        // all threads have joined by this point
+
+        switch (p) {
+            case 2: kf_bfly2(Fout,fstride,st,m); break;
+            case 3: kf_bfly3(Fout,fstride,st,m); break;
+            case 4: kf_bfly4(Fout,fstride,st,m); break;
+            case 5: kf_bfly5(Fout,fstride,st,m); break;
+            default: kf_bfly_generic(Fout,fstride,st,m,p); break;
+        }
+        return;
+    }
+#endif
+
+    if (m==1) {
+        do{
+            *Fout = *f;
+            f += fstride*in_stride;
+        }while(++Fout != Fout_end );
+    }else{
+        do{
+            // recursive call:
+            // DFT of size m*p performed by doing
+            // p instances of smaller DFTs of size m,
+            // each one takes a decimated version of the input
+            kf_work( Fout , f, fstride*p, in_stride, factors,st);
+            f += fstride*in_stride;
+        }while( (Fout += m) != Fout_end );
+    }
+
+    Fout=Fout_beg;
+
+    // recombine the p smaller DFTs
+    switch (p) {
+        case 2: kf_bfly2(Fout,fstride,st,m); break;
+        case 3: kf_bfly3(Fout,fstride,st,m); break;
+        case 4: kf_bfly4(Fout,fstride,st,m); break;
+        case 5: kf_bfly5(Fout,fstride,st,m); break;
+        default: kf_bfly_generic(Fout,fstride,st,m,p); break;
+    }
+}
+
+/*  facbuf is populated by p1,m1,p2,m2, ...
+    where
+    p[i] * m[i] = m[i-1]
+    m0 = n                  */
+static
+void kf_factor(int n,int * facbuf)
+{
+    int p=4;
+    double floor_sqrt;
+    floor_sqrt = floor( sqrt((double)n) );
+
+    /*factor out powers of 4, powers of 2, then any remaining primes */
+    do {
+        while (n % p) {
+            switch (p) {
+                case 4: p = 2; break;
+                case 2: p = 3; break;
+                default: p += 2; break;
+            }
+            if (p > floor_sqrt)
+                p = n;          /* no more factors, skip to end */
+        }
+        n /= p;
+        *facbuf++ = p;
+        *facbuf++ = n;
+    } while (n > 1);
+}
+
+/*
+ *
+ * User-callable function to allocate all necessary storage space for the fft.
+ *
+ * The return value is a contiguous block of memory, allocated with malloc.  As such,
+ * It can be freed with free(), rather than a kiss_fft-specific function.
+ * */
+kiss_fft_cfg kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem )
+{
+    KISS_FFT_ALIGN_CHECK(mem)
+
+    kiss_fft_cfg st=NULL;
+    // check for overflow condition {memneeded > SIZE_MAX}.
+    if (nfft >= (SIZE_MAX - 2*sizeof(struct kiss_fft_state))/sizeof(kiss_fft_cpx))
+        return NULL;
+
+    size_t memneeded = KISS_FFT_ALIGN_SIZE_UP(sizeof(struct kiss_fft_state)
+        + sizeof(kiss_fft_cpx)*(nfft-1)); /* twiddle factors*/
+
+    if ( lenmem==NULL ) {
+        st = ( kiss_fft_cfg)KISS_FFT_MALLOC( memneeded );
+    }else{
+        if (mem != NULL && *lenmem >= memneeded)
+            st = (kiss_fft_cfg)mem;
+        *lenmem = memneeded;
+    }
+    if (st) {
+        int i;
+        st->nfft=nfft;
+        st->inverse = inverse_fft;
+
+        for (i=0;i<nfft;++i) {
+            const double pi=3.141592653589793238462643383279502884197169399375105820974944;
+            double phase = -2*pi*i / nfft;
+            if (st->inverse)
+                phase *= -1;
+            kf_cexp(st->twiddles+i, phase );
+        }
+
+        kf_factor(nfft,st->factors);
+    }
+    return st;
+}
+
+
+void kiss_fft_stride(kiss_fft_cfg st,const kiss_fft_cpx *fin,kiss_fft_cpx *fout,int in_stride)
+{
+    if (fin == fout) {
+        //NOTE: this is not really an in-place FFT algorithm.
+        //It just performs an out-of-place FFT into a temp buffer
+        if (fout == NULL){
+            KISS_FFT_ERROR("fout buffer NULL.");
+        return;
+        }
+
+        kiss_fft_cpx * tmpbuf = (kiss_fft_cpx*)KISS_FFT_TMP_ALLOC( sizeof(kiss_fft_cpx)*st->nfft);
+        if (tmpbuf == NULL){
+            KISS_FFT_ERROR("Memory allocation error.");
+        return;
+        }
+
+
+
+        kf_work(tmpbuf,fin,1,in_stride, st->factors,st);
+        memcpy(fout,tmpbuf,sizeof(kiss_fft_cpx)*st->nfft);
+        KISS_FFT_TMP_FREE(tmpbuf);
+    }else{
+        kf_work( fout, fin, 1,in_stride, st->factors,st );
+    }
+}
+
+void kiss_fft(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout)
+{
+    kiss_fft_stride(cfg,fin,fout,1);
+}
+
+
+void kiss_fft_cleanup(void)
+{
+    // nothing needed any more
+}
+
+int kiss_fft_next_fast_size(int n)
+{
+    while(1) {
+        int m=n;
+        while ( (m%2) == 0 ) m/=2;
+        while ( (m%3) == 0 ) m/=3;
+        while ( (m%5) == 0 ) m/=5;
+        if (m<=1)
+            break; /* n is completely factorable by twos, threes, and fives */
+        n++;
+    }
+    return n;
+}

--- a/vendor/kissfft/kiss_fft.h
+++ b/vendor/kissfft/kiss_fft.h
@@ -1,0 +1,184 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#ifndef KISS_FFT_H
+#define KISS_FFT_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+
+// Define KISS_FFT_SHARED macro to properly export symbols
+#ifdef KISS_FFT_SHARED
+# ifdef _WIN32
+#  ifdef KISS_FFT_BUILD
+#   define KISS_FFT_API __declspec(dllexport)
+#  else
+#   define KISS_FFT_API __declspec(dllimport)
+#  endif
+# else
+#  define KISS_FFT_API __attribute__ ((visibility ("default")))
+# endif
+#else
+# define KISS_FFT_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ATTENTION!
+ If you would like a :
+ -- a utility that will handle the caching of fft objects
+ -- real-only (no imaginary time component ) FFT
+ -- a multi-dimensional FFT
+ -- a command-line utility to perform ffts
+ -- a command-line utility to perform fast-convolution filtering
+
+ Then see kfc.h kiss_fftr.h kiss_fftnd.h fftutil.c kiss_fastfir.c
+  in the tools/ directory.
+*/
+
+/* User may override KISS_FFT_MALLOC and/or KISS_FFT_FREE. */
+#ifdef USE_SIMD
+#ifdef HAVE_LASX
+# include <lasxintrin.h>
+# define kiss_fft_scalar __m256
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC(nbytes) aligned_alloc(32, KISS_FFT_ALIGN_SIZE_UP(nbytes))
+#  define KISS_FFT_ALIGN_CHECK(ptr)
+#  define KISS_FFT_ALIGN_SIZE_UP(size) ((size + 31UL) & ~0x1FUL)
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE free
+# endif
+#elif defined(HAVE_LSX)
+# include <lsxintrin.h>
+# define kiss_fft_scalar __m128
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC(nbytes) aligned_alloc(16, KISS_FFT_ALIGN_SIZE_UP(nbytes))
+#  define KISS_FFT_ALIGN_CHECK(ptr)
+#  define KISS_FFT_ALIGN_SIZE_UP(size) ((size + 15UL) & ~0xFUL)
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE free
+# endif
+#else
+# include <xmmintrin.h>
+# define kiss_fft_scalar __m128
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC(nbytes) _mm_malloc(nbytes,16)
+#  define KISS_FFT_ALIGN_CHECK(ptr)
+#  define KISS_FFT_ALIGN_SIZE_UP(size) ((size + 15UL) & ~0xFUL)
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE _mm_free
+# endif
+#endif
+#else
+# define KISS_FFT_ALIGN_CHECK(ptr)
+# define KISS_FFT_ALIGN_SIZE_UP(size) (size)
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC malloc
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE free
+# endif
+#endif
+
+
+#ifdef FIXED_POINT
+#include <stdint.h>
+# if (FIXED_POINT == 32)
+#  define kiss_fft_scalar int32_t
+# else	
+#  define kiss_fft_scalar int16_t
+# endif
+#else
+# ifndef kiss_fft_scalar
+/*  default is float */
+#   define kiss_fft_scalar float
+# endif
+#endif
+
+typedef struct {
+    kiss_fft_scalar r;
+    kiss_fft_scalar i;
+}kiss_fft_cpx;
+
+typedef struct kiss_fft_state* kiss_fft_cfg;
+
+/* 
+ *  kiss_fft_alloc
+ *  
+ *  Initialize a FFT (or IFFT) algorithm's cfg/state buffer.
+ *
+ *  typical usage:      kiss_fft_cfg mycfg=kiss_fft_alloc(1024,0,NULL,NULL);
+ *
+ *  The return value from fft_alloc is a cfg buffer used internally
+ *  by the fft routine or NULL.
+ *
+ *  If lenmem is NULL, then kiss_fft_alloc will allocate a cfg buffer using malloc.
+ *  The returned value should be free()d when done to avoid memory leaks.
+ *  
+ *  The state can be placed in a user supplied buffer 'mem':
+ *  If lenmem is not NULL and mem is not NULL and *lenmem is large enough,
+ *      then the function places the cfg in mem and the size used in *lenmem
+ *      and returns mem.
+ *  
+ *  If lenmem is not NULL and ( mem is NULL or *lenmem is not large enough),
+ *      then the function returns NULL and places the minimum cfg 
+ *      buffer size in *lenmem.
+ * */
+
+kiss_fft_cfg KISS_FFT_API kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem);
+
+/*
+ * kiss_fft(cfg,in_out_buf)
+ *
+ * Perform an FFT on a complex input buffer.
+ * for a forward FFT,
+ * fin should be  f[0] , f[1] , ... ,f[nfft-1]
+ * fout will be   F[0] , F[1] , ... ,F[nfft-1]
+ * Note that each element is complex and can be accessed like
+    f[k].r and f[k].i
+ * */
+void KISS_FFT_API kiss_fft(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout);
+
+/*
+ A more generic version of the above function. It reads its input from every Nth sample.
+ * */
+void KISS_FFT_API kiss_fft_stride(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout,int fin_stride);
+
+/* If kiss_fft_alloc allocated a buffer, it is one contiguous 
+   buffer and can be simply free()d when no longer needed*/
+#define kiss_fft_free KISS_FFT_FREE
+
+/*
+ Cleans up some memory that gets managed internally. Not necessary to call, but it might clean up 
+ your compiler output to call this before you exit.
+*/
+void KISS_FFT_API kiss_fft_cleanup(void);
+	
+
+/*
+ * Returns the smallest integer k, such that k>=n and k has only "fast" factors (2,3,5)
+ */
+int KISS_FFT_API kiss_fft_next_fast_size(int n);
+
+/* for real ffts, we need an even size */
+#define kiss_fftr_next_fast_size_real(n) \
+        (kiss_fft_next_fast_size( ((n)+1)>>1)<<1)
+
+#ifdef __cplusplus
+} 
+#endif
+
+#endif

--- a/vendor/kissfft/kiss_fft_log.h
+++ b/vendor/kissfft/kiss_fft_log.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#ifndef kiss_fft_log_h
+#define kiss_fft_log_h
+
+#define ERROR 1
+#define WARNING 2
+#define INFO 3
+#define DEBUG 4
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+#if defined(NDEBUG)
+# define KISS_FFT_LOG_MSG(severity, ...) ((void)0)
+#else
+# define KISS_FFT_LOG_MSG(severity, ...) \
+    fprintf(stderr, "[" #severity "] " __FILE__ ":" TOSTRING(__LINE__) " "); \
+    fprintf(stderr, __VA_ARGS__); \
+    fprintf(stderr, "\n")
+#endif
+
+#define KISS_FFT_ERROR(...) KISS_FFT_LOG_MSG(ERROR, __VA_ARGS__)
+#define KISS_FFT_WARNING(...) KISS_FFT_LOG_MSG(WARNING, __VA_ARGS__)
+#define KISS_FFT_INFO(...) KISS_FFT_LOG_MSG(INFO, __VA_ARGS__)
+#define KISS_FFT_DEBUG(...) KISS_FFT_LOG_MSG(DEBUG, __VA_ARGS__)
+
+
+
+#endif /* kiss_fft_log_h */


### PR DESCRIPTION
## Summary

- Vendor KissFFT (BSD-3-Clause) in vendor/kissfft/ — replaces the O(N^2) naive DFT
- Rewrite FFTProcessor.cpp using kiss_fft complex FFT; RAII KissCfg wrapper handles alloc/free; fft:: namespace API unchanged, all callers unaffected
- CMakeLists.txt: add C language, kissfft static library, link into addon/CLI/tests targets
- binding.gyp: add kissfft source and include path
- fft CLI command gains --full (Welch averaged periodogram over entire file), --offset, and --bins options
- Full-file analysis of a 98s stereo file: 36779 windows in ~3s vs several minutes with the old DFT

## Test plan

- [ ] CI cmake-tests pass
- [ ] CI clang-format check passes
- [ ] CI cppcheck passes
- [ ] fft --full produces non-zero spectrum on a real WAV file