### PR TITLE
refactor: Float32Array N-API boundary (Phase 3)

### DIFF
--- a/include/audio/FFTProcessor.hpp
+++ b/include/audio/FFTProcessor.hpp
@@ -5,7 +5,7 @@
 
 namespace fft {
 
-std::vector<std::complex<double>> transform(const std::vector<double> &input);
+std::vector<std::complex<double>> transform(const std::vector<float> &input);
 std::vector<double> inverse(const std::vector<std::complex<double>> &spectrum);
 std::vector<double> magnitude(const std::vector<std::complex<double>> &spectrum);
 

--- a/src/addon/addon.cpp
+++ b/src/addon/addon.cpp
@@ -11,55 +11,66 @@
 
 namespace {
 
-std::vector<double> toDoubleVector(const Napi::Env &env, const Napi::Array &array,
-                                   const char *context) {
-    std::vector<double> values(array.Length());
-    for (uint32_t i = 0; i < array.Length(); ++i) {
-        Napi::Value v = array.Get(i);
-        if (!v.IsNumber()) {
-            throw Napi::TypeError::New(env, std::string(context) + " must contain only numbers");
-        }
-        values[i] = v.As<Napi::Number>().DoubleValue();
-    }
-    return values;
-}
-
-std::vector<std::complex<double>> toComplexVector(const Napi::Env &env, const Napi::Array &array,
-                                                  const char *context) {
-    std::vector<std::complex<double>> values(array.Length());
-    for (uint32_t i = 0; i < array.Length(); ++i) {
-        Napi::Value v = array.Get(i);
-        if (!v.IsObject()) {
-            throw Napi::TypeError::New(env, std::string(context) +
-                                                " entries must be objects with real/imag");
-        }
-        Napi::Object bin = v.As<Napi::Object>();
-        if (!bin.Has("real") || !bin.Has("imag")) {
-            throw Napi::TypeError::New(env, std::string(context) +
-                                                " entries must have real and imag fields");
-        }
-        values[i] = std::complex<double>(bin.Get("real").As<Napi::Number>().DoubleValue(),
-                                         bin.Get("imag").As<Napi::Number>().DoubleValue());
-    }
-    return values;
-}
-
-Napi::Array vectorToNumberArray(const Napi::Env &env, const std::vector<double> &values) {
-    Napi::Array result = Napi::Array::New(env, values.size());
-    for (size_t i = 0; i < values.size(); ++i)
-        result[i] = Napi::Number::New(env, values[i]);
+std::vector<float> readFloat32Array(const Napi::CallbackInfo &info, uint32_t idx,
+                                    const char *ctx) {
+    Napi::Env env = info.Env();
+    if (idx >= info.Length() || !info[idx].IsTypedArray())
+        throw Napi::TypeError::New(env, std::string(ctx) + " must be a Float32Array");
+    Napi::TypedArray ta = info[idx].As<Napi::TypedArray>();
+    if (ta.TypedArrayType() != napi_float32_array)
+        throw Napi::TypeError::New(env, std::string(ctx) + " must be a Float32Array");
+    Napi::Float32Array fa = ta.As<Napi::Float32Array>();
+    std::vector<float> result(fa.ElementLength());
+    for (size_t i = 0; i < fa.ElementLength(); ++i)
+        result[i] = fa[i];
     return result;
 }
 
-Napi::Array complexVectorToArray(const Napi::Env &env,
-                                 const std::vector<std::complex<double>> &spectrum) {
-    Napi::Array result = Napi::Array::New(env, spectrum.size());
+Napi::Float32Array makeFloat32Array(Napi::Env env, const std::vector<float> &values) {
+    Napi::Float32Array arr = Napi::Float32Array::New(env, values.size());
+    for (size_t i = 0; i < values.size(); ++i)
+        arr[i] = values[i];
+    return arr;
+}
+
+Napi::Float32Array makeFloat32ArrayFromDouble(Napi::Env env, const std::vector<double> &values) {
+    Napi::Float32Array arr = Napi::Float32Array::New(env, values.size());
+    for (size_t i = 0; i < values.size(); ++i)
+        arr[i] = static_cast<float>(values[i]);
+    return arr;
+}
+
+Napi::Object makeSpectrumObject(Napi::Env env,
+                                const std::vector<std::complex<double>> &spectrum) {
+    Napi::Float32Array real = Napi::Float32Array::New(env, spectrum.size());
+    Napi::Float32Array imag = Napi::Float32Array::New(env, spectrum.size());
     for (size_t i = 0; i < spectrum.size(); ++i) {
-        Napi::Object bin = Napi::Object::New(env);
-        bin.Set("real", Napi::Number::New(env, spectrum[i].real()));
-        bin.Set("imag", Napi::Number::New(env, spectrum[i].imag()));
-        result[i] = bin;
+        real[i] = static_cast<float>(spectrum[i].real());
+        imag[i] = static_cast<float>(spectrum[i].imag());
     }
+    Napi::Object obj = Napi::Object::New(env);
+    obj.Set("real", real);
+    obj.Set("imag", imag);
+    return obj;
+}
+
+std::vector<std::complex<double>> readSpectrumObject(Napi::Env env, const Napi::Object &obj,
+                                                     const char *ctx) {
+    if (!obj.Has("real") || !obj.Has("imag"))
+        throw Napi::TypeError::New(env,
+                                   std::string(ctx) + " must have real and imag Float32Arrays");
+    Napi::Value realVal = obj.Get("real");
+    Napi::Value imagVal = obj.Get("imag");
+    if (!realVal.IsTypedArray() || !imagVal.IsTypedArray())
+        throw Napi::TypeError::New(env, std::string(ctx) + " real and imag must be Float32Arrays");
+    Napi::Float32Array realArr = realVal.As<Napi::Float32Array>();
+    Napi::Float32Array imagArr = imagVal.As<Napi::Float32Array>();
+    if (realArr.ElementLength() != imagArr.ElementLength())
+        throw Napi::TypeError::New(env,
+                                   std::string(ctx) + " real and imag must have the same length");
+    std::vector<std::complex<double>> result(realArr.ElementLength());
+    for (size_t i = 0; i < realArr.ElementLength(); ++i)
+        result[i] = {static_cast<double>(realArr[i]), static_cast<double>(imagArr[i])};
     return result;
 }
 
@@ -68,24 +79,22 @@ Napi::Array complexVectorToArray(const Napi::Env &env,
 Napi::Value GenerateWindow(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
-    if (info.Length() < 2 || !info[0].IsString() || !info[1].IsNumber()) {
+    if (info.Length() < 2 || !info[0].IsString() || !info[1].IsNumber())
         throw Napi::TypeError::New(env, "Expected (windowType: string, size: number)");
-    }
 
     const std::string typeStr = info[0].As<Napi::String>();
     const size_t size = info[1].As<Napi::Number>().Uint32Value();
 
     window::Type type;
-    if (typeStr == "hann") {
+    if (typeStr == "hann")
         type = window::Type::Hann;
-    } else if (typeStr == "hamming") {
+    else if (typeStr == "hamming")
         type = window::Type::Hamming;
-    } else {
+    else
         throw Napi::TypeError::New(env, "Window type must be 'hann' or 'hamming'");
-    }
 
     try {
-        return vectorToNumberArray(env, window::generate(type, size));
+        return makeFloat32ArrayFromDouble(env, window::generate(type, size));
     } catch (const std::exception &e) {
         throw Napi::Error::New(env, e.what());
     }
@@ -94,26 +103,24 @@ Napi::Value GenerateWindow(const Napi::CallbackInfo &info) {
 Napi::Value ApplyWindow(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
-    if (info.Length() < 2 || !info[0].IsArray() || !info[1].IsArray()) {
-        throw Napi::TypeError::New(env, "Expected (samples: number[], window: number[])");
-    }
-
-    Napi::Array samplesArray = info[0].As<Napi::Array>();
-    Napi::Array windowArray = info[1].As<Napi::Array>();
-
-    if (samplesArray.Length() != windowArray.Length()) {
-        throw Napi::TypeError::New(env, "Sample and window arrays must have the same length");
-    }
+    if (info.Length() < 2)
+        throw Napi::TypeError::New(env,
+                                   "Expected (samples: Float32Array, window: Float32Array)");
 
     try {
-        const std::vector<double> samplesD = toDoubleVector(env, samplesArray, "samples");
-        const std::vector<double> win = toDoubleVector(env, windowArray, "window");
+        std::vector<float> samples = readFloat32Array(info, 0, "samples");
+        std::vector<float> winF = readFloat32Array(info, 1, "window");
 
-        std::vector<float> samples(samplesD.begin(), samplesD.end());
-        window::apply(samples, win);
+        if (samples.size() != winF.size())
+            throw Napi::TypeError::New(env,
+                                       "Sample and window arrays must have the same length");
 
-        const std::vector<double> result(samples.begin(), samples.end());
-        return vectorToNumberArray(env, result);
+        const std::vector<double> winD(winF.begin(), winF.end());
+        window::apply(samples, winD);
+
+        return makeFloat32Array(env, samples);
+    } catch (const Napi::Error &) {
+        throw;
     } catch (const std::exception &e) {
         throw Napi::Error::New(env, e.what());
     }
@@ -122,18 +129,16 @@ Napi::Value ApplyWindow(const Napi::CallbackInfo &info) {
 Napi::Value FFT(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
-    if (info.Length() < 1 || !info[0].IsArray()) {
-        throw Napi::TypeError::New(env, "Expected (samples: number[])");
-    }
-
-    Napi::Array samplesArray = info[0].As<Napi::Array>();
-    if (samplesArray.Length() == 0) {
-        throw Napi::TypeError::New(env, "Input array cannot be empty");
-    }
+    if (info.Length() < 1)
+        throw Napi::TypeError::New(env, "Expected (samples: Float32Array)");
 
     try {
-        const std::vector<double> samples = toDoubleVector(env, samplesArray, "samples");
-        return complexVectorToArray(env, fft::transform(samples));
+        const std::vector<float> samples = readFloat32Array(info, 0, "samples");
+        if (samples.empty())
+            throw Napi::TypeError::New(env, "Input array cannot be empty");
+        return makeSpectrumObject(env, fft::transform(samples));
+    } catch (const Napi::Error &) {
+        throw;
     } catch (const std::exception &e) {
         throw Napi::Error::New(env, e.what());
     }
@@ -142,18 +147,17 @@ Napi::Value FFT(const Napi::CallbackInfo &info) {
 Napi::Value IFFT(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
-    if (info.Length() < 1 || !info[0].IsArray()) {
-        throw Napi::TypeError::New(env, "Expected (spectrum: {real:number, imag:number}[])");
-    }
-
-    Napi::Array spectrumArray = info[0].As<Napi::Array>();
-    if (spectrumArray.Length() == 0) {
-        throw Napi::TypeError::New(env, "Spectrum array cannot be empty");
-    }
+    if (info.Length() < 1 || !info[0].IsObject())
+        throw Napi::TypeError::New(
+            env, "Expected (spectrum: {real: Float32Array, imag: Float32Array})");
 
     try {
-        return vectorToNumberArray(env,
-                                   fft::inverse(toComplexVector(env, spectrumArray, "Spectrum")));
+        const auto spectrum = readSpectrumObject(env, info[0].As<Napi::Object>(), "spectrum");
+        if (spectrum.empty())
+            throw Napi::TypeError::New(env, "Spectrum cannot be empty");
+        return makeFloat32ArrayFromDouble(env, fft::inverse(spectrum));
+    } catch (const Napi::Error &) {
+        throw;
     } catch (const std::exception &e) {
         throw Napi::Error::New(env, e.what());
     }
@@ -162,13 +166,15 @@ Napi::Value IFFT(const Napi::CallbackInfo &info) {
 Napi::Value FFTMagnitude(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
-    if (info.Length() < 1 || !info[0].IsArray()) {
-        throw Napi::TypeError::New(env, "Expected (spectrum: {real:number, imag:number}[])");
-    }
+    if (info.Length() < 1 || !info[0].IsObject())
+        throw Napi::TypeError::New(
+            env, "Expected (spectrum: {real: Float32Array, imag: Float32Array})");
 
     try {
-        return vectorToNumberArray(
-            env, fft::magnitude(toComplexVector(env, info[0].As<Napi::Array>(), "Spectrum")));
+        const auto spectrum = readSpectrumObject(env, info[0].As<Napi::Object>(), "spectrum");
+        return makeFloat32ArrayFromDouble(env, fft::magnitude(spectrum));
+    } catch (const Napi::Error &) {
+        throw;
     } catch (const std::exception &e) {
         throw Napi::Error::New(env, e.what());
     }
@@ -177,9 +183,8 @@ Napi::Value FFTMagnitude(const Napi::CallbackInfo &info) {
 Napi::Value Process(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
-    if (info.Length() < 1 || !info[0].IsString()) {
+    if (info.Length() < 1 || !info[0].IsString())
         throw Napi::TypeError::New(env, "Input path must be a string");
-    }
 
     const std::string inputPath = info[0].As<Napi::String>();
 
@@ -225,9 +230,8 @@ Napi::Value Process(const Napi::CallbackInfo &info) {
 Napi::Value Inspect(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
-    if (info.Length() < 1 || !info[0].IsString()) {
+    if (info.Length() < 1 || !info[0].IsString())
         throw Napi::TypeError::New(env, "Input path must be a string");
-    }
 
     const std::string inputPath = info[0].As<Napi::String>();
 

--- a/src/addon/addon.cpp
+++ b/src/addon/addon.cpp
@@ -11,8 +11,7 @@
 
 namespace {
 
-std::vector<float> readFloat32Array(const Napi::CallbackInfo &info, uint32_t idx,
-                                    const char *ctx) {
+std::vector<float> readFloat32Array(const Napi::CallbackInfo &info, uint32_t idx, const char *ctx) {
     Napi::Env env = info.Env();
     if (idx >= info.Length() || !info[idx].IsTypedArray())
         throw Napi::TypeError::New(env, std::string(ctx) + " must be a Float32Array");
@@ -40,8 +39,7 @@ Napi::Float32Array makeFloat32ArrayFromDouble(Napi::Env env, const std::vector<d
     return arr;
 }
 
-Napi::Object makeSpectrumObject(Napi::Env env,
-                                const std::vector<std::complex<double>> &spectrum) {
+Napi::Object makeSpectrumObject(Napi::Env env, const std::vector<std::complex<double>> &spectrum) {
     Napi::Float32Array real = Napi::Float32Array::New(env, spectrum.size());
     Napi::Float32Array imag = Napi::Float32Array::New(env, spectrum.size());
     for (size_t i = 0; i < spectrum.size(); ++i) {
@@ -104,16 +102,14 @@ Napi::Value ApplyWindow(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
     if (info.Length() < 2)
-        throw Napi::TypeError::New(env,
-                                   "Expected (samples: Float32Array, window: Float32Array)");
+        throw Napi::TypeError::New(env, "Expected (samples: Float32Array, window: Float32Array)");
 
     try {
         std::vector<float> samples = readFloat32Array(info, 0, "samples");
         std::vector<float> winF = readFloat32Array(info, 1, "window");
 
         if (samples.size() != winF.size())
-            throw Napi::TypeError::New(env,
-                                       "Sample and window arrays must have the same length");
+            throw Napi::TypeError::New(env, "Sample and window arrays must have the same length");
 
         const std::vector<double> winD(winF.begin(), winF.end());
         window::apply(samples, winD);
@@ -148,8 +144,8 @@ Napi::Value IFFT(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
     if (info.Length() < 1 || !info[0].IsObject())
-        throw Napi::TypeError::New(
-            env, "Expected (spectrum: {real: Float32Array, imag: Float32Array})");
+        throw Napi::TypeError::New(env,
+                                   "Expected (spectrum: {real: Float32Array, imag: Float32Array})");
 
     try {
         const auto spectrum = readSpectrumObject(env, info[0].As<Napi::Object>(), "spectrum");
@@ -167,8 +163,8 @@ Napi::Value FFTMagnitude(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
     if (info.Length() < 1 || !info[0].IsObject())
-        throw Napi::TypeError::New(
-            env, "Expected (spectrum: {real: Float32Array, imag: Float32Array})");
+        throw Napi::TypeError::New(env,
+                                   "Expected (spectrum: {real: Float32Array, imag: Float32Array})");
 
     try {
         const auto spectrum = readSpectrumObject(env, info[0].As<Napi::Object>(), "spectrum");

--- a/src/audio/FFTProcessor.cpp
+++ b/src/audio/FFTProcessor.cpp
@@ -20,7 +20,7 @@ struct KissCfg {
 
 namespace fft {
 
-std::vector<std::complex<double>> transform(const std::vector<double> &input) {
+std::vector<std::complex<double>> transform(const std::vector<float> &input) {
     if (input.empty())
         throw dissonance::DspError("FFT input cannot be empty");
 
@@ -29,7 +29,7 @@ std::vector<std::complex<double>> transform(const std::vector<double> &input) {
 
     std::vector<kiss_fft_cpx> in(N), out(N);
     for (int i = 0; i < N; ++i) {
-        in[i].r = static_cast<float>(input[i]);
+        in[i].r = input[i];
         in[i].i = 0.0f;
     }
 

--- a/src/audio/WavProcessor.cpp
+++ b/src/audio/WavProcessor.cpp
@@ -103,8 +103,7 @@ ProcessedWav processWavFile(const std::string &inputPath, const ProcessingOption
 
                 window::apply(block, win);
 
-                std::vector<double> blockD(block.begin(), block.end());
-                auto spectrum = fft::transform(blockD);
+                auto spectrum = fft::transform(block);
 
                 const size_t cutoff = spectrum.size() / 4;
                 for (size_t k = cutoff; k < spectrum.size(); ++k)

--- a/src/cli/Commands.cpp
+++ b/src/cli/Commands.cpp
@@ -120,8 +120,7 @@ int Commands::handleFft(const std::string &inputPath, int argc, char **argv, int
 
             window::apply(blockF, win);
 
-            std::vector<double> blockD(blockF.begin(), blockF.end());
-            auto mags = fft::magnitude(fft::transform(blockD));
+            auto mags = fft::magnitude(fft::transform(blockF));
 
             for (size_t k = 0; k < frameSize; ++k)
                 accumulated[k] += mags[k];
@@ -148,8 +147,7 @@ int Commands::handleFft(const std::string &inputPath, int argc, char **argv, int
 
         window::apply(blockF, win);
 
-        std::vector<double> blockD(blockF.begin(), blockF.end());
-        accumulated = fft::magnitude(fft::transform(blockD));
+        accumulated = fft::magnitude(fft::transform(blockF));
         accumulated.resize(frameSize, 0.0);
         windowCount = 1;
     }

--- a/tests/fft_processor_test.cpp
+++ b/tests/fft_processor_test.cpp
@@ -1,14 +1,14 @@
 #include <gtest/gtest.h>
-#include <vector>
 #include <complex>
+#include <vector>
 
 #include "audio/FFTProcessor.hpp"
 #include "core/Errors.hpp"
 
-constexpr double EPS = 1e-6;
+constexpr double EPS = 1e-5;
 
 TEST(FFTProcessorTest, ImpulseHasFlatSpectrum) {
-    std::vector<double> impulse = {1.0, 0.0, 0.0, 0.0};
+    std::vector<float> impulse = {1.0f, 0.0f, 0.0f, 0.0f};
     auto spectrum = fft::transform(impulse);
 
     ASSERT_EQ(spectrum.size(), impulse.size());
@@ -19,29 +19,29 @@ TEST(FFTProcessorTest, ImpulseHasFlatSpectrum) {
 }
 
 TEST(FFTProcessorTest, InverseReconstructsImpulse) {
-    std::vector<double> impulse = {1.0, 0.0, 0.0, 0.0};
+    std::vector<float> impulse = {1.0f, 0.0f, 0.0f, 0.0f};
     auto spectrum = fft::transform(impulse);
     auto time = fft::inverse(spectrum);
 
     ASSERT_EQ(time.size(), impulse.size());
     for (size_t i = 0; i < time.size(); ++i) {
-        EXPECT_NEAR(time[i], impulse[i], EPS);
+        EXPECT_NEAR(time[i], static_cast<double>(impulse[i]), EPS);
     }
 }
 
 TEST(FFTProcessorTest, RoundTripSignal) {
-    std::vector<double> signal = {0.0, 1.0, 0.0, -1.0};
+    std::vector<float> signal = {0.0f, 1.0f, 0.0f, -1.0f};
     auto spectrum = fft::transform(signal);
     auto time = fft::inverse(spectrum);
 
     ASSERT_EQ(time.size(), signal.size());
     for (size_t i = 0; i < time.size(); ++i) {
-        EXPECT_NEAR(time[i], signal[i], EPS);
+        EXPECT_NEAR(time[i], static_cast<double>(signal[i]), EPS);
     }
 }
 
 TEST(FFTProcessorTest, MagnitudeMatchesSize) {
-    std::vector<double> signal = {0.0, 1.0, 0.0, -1.0};
+    std::vector<float> signal = {0.0f, 1.0f, 0.0f, -1.0f};
     auto spectrum = fft::transform(signal);
     auto mags = fft::magnitude(spectrum);
 
@@ -49,7 +49,7 @@ TEST(FFTProcessorTest, MagnitudeMatchesSize) {
 }
 
 TEST(FFTProcessorTest, ThrowsOnEmptyInput) {
-    std::vector<double> emptyReal;
+    std::vector<float> emptyReal;
     std::vector<std::complex<double>> emptyComplex;
 
     EXPECT_THROW(fft::transform(emptyReal), dissonance::DspError);

--- a/tests/js/test-fft.js
+++ b/tests/js/test-fft.js
@@ -1,33 +1,44 @@
 // Simple FFT/iFFT test script
 const core = require('../../build/Release/dissonance_core.node');
 
-function approxEqual(a, b, eps = 1e-6) {
+function approxEqual(a, b, eps = 1e-5) {
   return Math.abs(a - b) < eps;
 }
 
 console.log('Testing FFT/iFFT minimal chain');
 console.log('='.repeat(50));
 
-// 1) FFT of an impulse should be flat
-const impulse = [1, 0, 0, 0];
+// 1) FFT of an impulse should be flat: all bins have real=1, imag=0
+const impulse = new Float32Array([1, 0, 0, 0]);
 const spectrum = core.fft(impulse);
-const allOnes = spectrum.every(bin => approxEqual(bin.real, 1) && approxEqual(bin.imag, 0));
-console.log('\nFFT impulse -> flat spectrum:', allOnes ? 'PASS' : 'FAIL');
+const allOnesReal = Array.from(spectrum.real).every(v => approxEqual(v, 1));
+const allZerosImag = Array.from(spectrum.imag).every(v => approxEqual(v, 0));
+console.log('\nFFT impulse -> flat real:', allOnesReal ? 'PASS' : 'FAIL');
+console.log('FFT impulse -> zero imag:', allZerosImag ? 'PASS' : 'FAIL');
 
 // 2) iFFT of that spectrum should reconstruct the impulse
 const reconstructedImpulse = core.ifft(spectrum);
-const impulseMatches = reconstructedImpulse.every((v, i) => approxEqual(v, impulse[i]));
+const impulseMatches = Array.from(reconstructedImpulse).every((v, i) => approxEqual(v, impulse[i]));
 console.log('iFFT reconstructs impulse:', impulseMatches ? 'PASS' : 'FAIL');
 
 // 3) Round-trip on a small real signal
-const signal = [0, 1, 0, -1];
+const signal = new Float32Array([0, 1, 0, -1]);
 const signalSpectrum = core.fft(signal);
 const signalBack = core.ifft(signalSpectrum);
-const roundTripOk = signalBack.every((v, i) => approxEqual(v, signal[i]));
+const roundTripOk = Array.from(signalBack).every((v, i) => approxEqual(v, signal[i]));
 console.log('\nRound-trip signal -> spectrum -> signal:', roundTripOk ? 'PASS' : 'FAIL');
 
-// 4) Magnitude sanity check
+// 4) Magnitude sanity check — length matches bin count
 const magnitudes = core.fftMagnitude(signalSpectrum);
-console.log('Magnitude length correct:', magnitudes.length === signalSpectrum.length ? 'PASS' : 'FAIL');
+const lenOk = magnitudes.length === signal.length;
+console.log('Magnitude length correct:', lenOk ? 'PASS' : 'FAIL');
+
+// 5) Spectrum shape check — real and imag are Float32Arrays of same length
+const shapeOk =
+  spectrum.real instanceof Float32Array &&
+  spectrum.imag instanceof Float32Array &&
+  spectrum.real.length === impulse.length &&
+  spectrum.imag.length === impulse.length;
+console.log('Spectrum has {real, imag} Float32Arrays:', shapeOk ? 'PASS' : 'FAIL');
 
 console.log('\nDone.');

--- a/tests/js/test-window.js
+++ b/tests/js/test-window.js
@@ -8,28 +8,27 @@ console.log('Testing Window Functions\n' + '='.repeat(50));
 console.log('\n1. Generate Hann Window (size=8)');
 try {
     const hannWindow = core.generateWindow('hann', 8);
-    console.log('   Hann window:', hannWindow.map(v => v.toFixed(4)).join(', '));
-    
-    // Verify it starts and ends at 0 (or very close to 0)
+    console.log('   Hann window:', Array.from(hannWindow).map(v => v.toFixed(4)).join(', '));
+    console.log('   Returns Float32Array:', hannWindow instanceof Float32Array ? 'PASS' : 'FAIL');
+
     if (Math.abs(hannWindow[0]) < 0.001 && Math.abs(hannWindow[7]) < 0.001) {
-        console.log('   ✓ Correctly tapers to ~0 at edges');
+        console.log('   Correctly tapers to ~0 at edges: PASS');
     }
 } catch (e) {
-    console.error('   ✗ Error:', e.message);
+    console.error('   Error:', e.message);
 }
 
 // Test 2: Generate Hamming window
 console.log('\n2. Generate Hamming Window (size=8)');
 try {
     const hammingWindow = core.generateWindow('hamming', 8);
-    console.log('   Hamming window:', hammingWindow.map(v => v.toFixed(4)).join(', '));
-    
-    // Verify it doesn't reach 0 at the edges (should be ~0.08)
+    console.log('   Hamming window:', Array.from(hammingWindow).map(v => v.toFixed(4)).join(', '));
+
     if (hammingWindow[0] > 0.05 && hammingWindow[7] > 0.05) {
-        console.log('   ✓ Correctly stays above 0 at edges (~0.08)');
+        console.log('   Correctly stays above 0 at edges (~0.08): PASS');
     }
 } catch (e) {
-    console.error('   ✗ Error:', e.message);
+    console.error('   Error:', e.message);
 }
 
 // Test 3: Compare larger window sizes
@@ -37,55 +36,54 @@ console.log('\n3. Generate larger windows (size=512)');
 try {
     const hann512 = core.generateWindow('hann', 512);
     const hamming512 = core.generateWindow('hamming', 512);
-    
+
     console.log('   Hann[0]:', hann512[0].toFixed(6), 'Hann[256]:', hann512[256].toFixed(6));
     console.log('   Hamming[0]:', hamming512[0].toFixed(6), 'Hamming[256]:', hamming512[256].toFixed(6));
-    
-    // Both should peak at 1.0 in the middle
+
     if (Math.abs(hann512[256] - 1.0) < 0.01 && Math.abs(hamming512[256] - 1.0) < 0.01) {
-        console.log('   ✓ Both windows peak at ~1.0 in the center');
+        console.log('   Both windows peak at ~1.0 in the center: PASS');
     }
 } catch (e) {
-    console.error('   ✗ Error:', e.message);
+    console.error('   Error:', e.message);
 }
 
-// Test 4: Apply window to sample data
+// Test 4: Apply window to sample data (Float32Array inputs)
 console.log('\n4. Apply Window to Sample Data');
 try {
-    const samples = [1000, 2000, 3000, 4000, 3000, 2000, 1000, 500];
+    const samples = new Float32Array([0.5, 0.8, 0.9, 1.0, 0.9, 0.8, 0.5, 0.2]);
     const window = core.generateWindow('hann', 8);
     const windowed = core.applyWindow(samples, window);
-    
-    console.log('   Original:', samples.join(', '));
-    console.log('   Window:', window.map(v => v.toFixed(3)).join(', '));
-    console.log('   Windowed:', windowed.map(v => v.toFixed(1)).join(', '));
-    
-    // Check that edges are attenuated
+
+    console.log('   Original:', Array.from(samples).map(v => v.toFixed(3)).join(', '));
+    console.log('   Window:', Array.from(window).map(v => v.toFixed(3)).join(', '));
+    console.log('   Windowed:', Array.from(windowed).map(v => v.toFixed(3)).join(', '));
+    console.log('   Returns Float32Array:', windowed instanceof Float32Array ? 'PASS' : 'FAIL');
+
     if (windowed[0] < samples[0] && windowed[7] < samples[7]) {
-        console.log('   ✓ Edges are correctly attenuated');
+        console.log('   Edges are correctly attenuated: PASS');
     }
 } catch (e) {
-    console.error('   ✗ Error:', e.message);
+    console.error('   Error:', e.message);
 }
 
 // Test 5: Error handling - invalid window type
 console.log('\n5. Error Handling - Invalid Window Type');
 try {
     core.generateWindow('blackman', 8);
-    console.error('   ✗ Should have thrown error for invalid type');
+    console.error('   Should have thrown error for invalid type: FAIL');
 } catch (e) {
-    console.log('   ✓ Correctly throws error:', e.message);
+    console.log('   Correctly throws error:', e.message, '-> PASS');
 }
 
 // Test 6: Error handling - mismatched sizes
 console.log('\n6. Error Handling - Mismatched Array Sizes');
 try {
-    const samples = [1, 2, 3, 4];
-    const window = [0.5, 0.5, 0.5];
+    const samples = new Float32Array([1, 2, 3, 4]);
+    const window = new Float32Array([0.5, 0.5, 0.5]);
     core.applyWindow(samples, window);
-    console.error('   ✗ Should have thrown error for size mismatch');
+    console.error('   Should have thrown error for size mismatch: FAIL');
 } catch (e) {
-    console.log('   ✓ Correctly throws error:', e.message);
+    console.log('   Correctly throws error:', e.message, '-> PASS');
 }
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## Summary

- fft::transform input changed from vector<double> to vector<float>, eliminating a float/double round-trip
- N-API boundary rewired: generateWindow, applyWindow, fft, ifft, fftMagnitude all exchange Float32Array instead of plain JS number arrays
- Complex spectrum boundary changed from array of {real, imag} objects to {real: Float32Array, imag: Float32Array}
- readFloat32Array / makeFloat32Array helpers replace toDoubleVector / vectorToNumberArray
- JS tests updated for new Float32Array API and spectrum shape

## Test plan

- [ ] CI cmake build + ctest pass
- [ ] CI clang-format check passes
- [ ] CI cppcheck passes
- [ ] node tests/js/test-fft.js all PASS
- [ ] node tests/js/test-window.js all PASS