### PR TITLE
refactor: async process() with Promise and full STFT loop (Phase 4)

### DIFF
--- a/include/audio/WavProcessor.hpp
+++ b/include/audio/WavProcessor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -17,6 +18,7 @@ struct FFTReport {
 struct ProcessingOptions {
     double gain = 0.8;
     std::string outputPath;
+    std::function<void(float)> progressCallback;
 };
 
 struct ProcessedWav {

--- a/src/addon/addon.cpp
+++ b/src/addon/addon.cpp
@@ -16,8 +16,7 @@ namespace {
 // Float32Array helpers
 // ---------------------------------------------------------------------------
 
-std::vector<float> readFloat32Array(const Napi::CallbackInfo &info, uint32_t idx,
-                                    const char *ctx) {
+std::vector<float> readFloat32Array(const Napi::CallbackInfo &info, uint32_t idx, const char *ctx) {
     Napi::Env env = info.Env();
     if (idx >= info.Length() || !info[idx].IsTypedArray())
         throw Napi::TypeError::New(env, std::string(ctx) + " must be a Float32Array");
@@ -45,8 +44,7 @@ Napi::Float32Array makeFloat32ArrayFromDouble(Napi::Env env, const std::vector<d
     return arr;
 }
 
-Napi::Object makeSpectrumObject(Napi::Env env,
-                                const std::vector<std::complex<double>> &spectrum) {
+Napi::Object makeSpectrumObject(Napi::Env env, const std::vector<std::complex<double>> &spectrum) {
     Napi::Float32Array real = Napi::Float32Array::New(env, spectrum.size());
     Napi::Float32Array imag = Napi::Float32Array::New(env, spectrum.size());
     for (size_t i = 0; i < spectrum.size(); ++i) {
@@ -97,8 +95,7 @@ Napi::Object buildProcessResult(Napi::Env env, const ProcessedWav &processed) {
     result.Set("listTags", listTags);
     result.Set("processedPath", Napi::String::New(env, processed.processedPath));
     result.Set("fftApplied", Napi::Boolean::New(env, processed.fftReport.applied));
-    result.Set("fftFramesProcessed",
-               Napi::Number::New(env, processed.fftReport.framesProcessed));
+    result.Set("fftFramesProcessed", Napi::Number::New(env, processed.fftReport.framesProcessed));
     result.Set("fftBins", Napi::Number::New(env, processed.fftReport.bins));
     result.Set("fftCutoffBin", Napi::Number::New(env, processed.fftReport.cutoffBin));
     return result;
@@ -109,7 +106,7 @@ Napi::Object buildProcessResult(Napi::Env env, const ProcessedWav &processed) {
 // ---------------------------------------------------------------------------
 
 class ProcessWorker : public Napi::AsyncWorker {
-public:
+  public:
     ProcessWorker(Napi::Env env, std::string inputPath, ProcessingOptions opts,
                   Napi::Promise::Deferred deferred)
         : Napi::AsyncWorker(env), inputPath_(std::move(inputPath)), opts_(std::move(opts)),
@@ -124,10 +121,9 @@ public:
         try {
             if (hasProgress_) {
                 opts_.progressCallback = [this](float progress) {
-                    tsfn_.NonBlockingCall(
-                        [progress](Napi::Env env, Napi::Function cb) {
-                            cb.Call({Napi::Number::New(env, progress)});
-                        });
+                    tsfn_.NonBlockingCall([progress](Napi::Env env, Napi::Function cb) {
+                        cb.Call({Napi::Number::New(env, progress)});
+                    });
                 };
             }
             result_ = processWavFile(inputPath_, opts_);
@@ -148,7 +144,7 @@ public:
         deferred_.Reject(e.Value());
     }
 
-private:
+  private:
     std::string inputPath_;
     ProcessingOptions opts_;
     ProcessedWav result_;
@@ -183,7 +179,7 @@ Napi::Value Process(const Napi::CallbackInfo &info) {
 
     if (info.Length() >= 3 && info[2].IsFunction()) {
         auto tsfn = Napi::ThreadSafeFunction::New(env, info[2].As<Napi::Function>(),
-                                                   "processProgress", 0, 1);
+                                                  "processProgress", 0, 1);
         worker->setProgressCallback(std::move(tsfn));
     }
 
@@ -263,16 +259,14 @@ Napi::Value ApplyWindow(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
     if (info.Length() < 2)
-        throw Napi::TypeError::New(env,
-                                   "Expected (samples: Float32Array, window: Float32Array)");
+        throw Napi::TypeError::New(env, "Expected (samples: Float32Array, window: Float32Array)");
 
     try {
         std::vector<float> samples = readFloat32Array(info, 0, "samples");
         std::vector<float> winF = readFloat32Array(info, 1, "window");
 
         if (samples.size() != winF.size())
-            throw Napi::TypeError::New(env,
-                                       "Sample and window arrays must have the same length");
+            throw Napi::TypeError::New(env, "Sample and window arrays must have the same length");
 
         const std::vector<double> winD(winF.begin(), winF.end());
         window::apply(samples, winD);
@@ -307,8 +301,8 @@ Napi::Value IFFT(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
     if (info.Length() < 1 || !info[0].IsObject())
-        throw Napi::TypeError::New(
-            env, "Expected (spectrum: {real: Float32Array, imag: Float32Array})");
+        throw Napi::TypeError::New(env,
+                                   "Expected (spectrum: {real: Float32Array, imag: Float32Array})");
 
     try {
         const auto spectrum = readSpectrumObject(env, info[0].As<Napi::Object>(), "spectrum");
@@ -326,8 +320,8 @@ Napi::Value FFTMagnitude(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
 
     if (info.Length() < 1 || !info[0].IsObject())
-        throw Napi::TypeError::New(
-            env, "Expected (spectrum: {real: Float32Array, imag: Float32Array})");
+        throw Napi::TypeError::New(env,
+                                   "Expected (spectrum: {real: Float32Array, imag: Float32Array})");
 
     try {
         const auto spectrum = readSpectrumObject(env, info[0].As<Napi::Object>(), "spectrum");

--- a/src/addon/addon.cpp
+++ b/src/addon/addon.cpp
@@ -1,4 +1,5 @@
 #include <napi.h>
+#include <fstream>
 #include <string>
 #include <complex>
 
@@ -10,6 +11,10 @@
 #include "core/Errors.hpp"
 
 namespace {
+
+// ---------------------------------------------------------------------------
+// Float32Array helpers
+// ---------------------------------------------------------------------------
 
 std::vector<float> readFloat32Array(const Napi::CallbackInfo &info, uint32_t idx,
                                     const char *ctx) {
@@ -72,6 +77,160 @@ std::vector<std::complex<double>> readSpectrumObject(Napi::Env env, const Napi::
     for (size_t i = 0; i < realArr.ElementLength(); ++i)
         result[i] = {static_cast<double>(realArr[i]), static_cast<double>(imagArr[i])};
     return result;
+}
+
+Napi::Object buildProcessResult(Napi::Env env, const ProcessedWav &processed) {
+    Napi::Object listTags = Napi::Object::New(env);
+    listTags.Set("title", Napi::String::New(env, processed.listTags.title));
+    listTags.Set("artist", Napi::String::New(env, processed.listTags.artist));
+    listTags.Set("comment", Napi::String::New(env, processed.listTags.comment));
+    listTags.Set("date", Napi::String::New(env, processed.listTags.date));
+    listTags.Set("software", Napi::String::New(env, processed.listTags.software));
+    listTags.Set("genre", Napi::String::New(env, processed.listTags.genre));
+    listTags.Set("copyright", Napi::String::New(env, processed.listTags.copyright));
+
+    Napi::Object result = Napi::Object::New(env);
+    result.Set("metadata", makeMetadataObject(env, processed.parser));
+    result.Set("otherChunks", makeOtherChunks(env, processed.parser));
+    result.Set("metadataText", Napi::String::New(env, processed.metadataText));
+    result.Set("waveformText", Napi::String::New(env, processed.waveformText));
+    result.Set("listTags", listTags);
+    result.Set("processedPath", Napi::String::New(env, processed.processedPath));
+    result.Set("fftApplied", Napi::Boolean::New(env, processed.fftReport.applied));
+    result.Set("fftFramesProcessed",
+               Napi::Number::New(env, processed.fftReport.framesProcessed));
+    result.Set("fftBins", Napi::Number::New(env, processed.fftReport.bins));
+    result.Set("fftCutoffBin", Napi::Number::New(env, processed.fftReport.cutoffBin));
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Async worker for process()
+// ---------------------------------------------------------------------------
+
+class ProcessWorker : public Napi::AsyncWorker {
+public:
+    ProcessWorker(Napi::Env env, std::string inputPath, ProcessingOptions opts,
+                  Napi::Promise::Deferred deferred)
+        : Napi::AsyncWorker(env), inputPath_(std::move(inputPath)), opts_(std::move(opts)),
+          deferred_(std::move(deferred)), hasProgress_(false) {}
+
+    void setProgressCallback(Napi::ThreadSafeFunction tsfn) {
+        tsfn_ = std::move(tsfn);
+        hasProgress_ = true;
+    }
+
+    void Execute() override {
+        try {
+            if (hasProgress_) {
+                opts_.progressCallback = [this](float progress) {
+                    tsfn_.NonBlockingCall(
+                        [progress](Napi::Env env, Napi::Function cb) {
+                            cb.Call({Napi::Number::New(env, progress)});
+                        });
+                };
+            }
+            result_ = processWavFile(inputPath_, opts_);
+        } catch (const std::exception &e) {
+            SetError(e.what());
+        }
+    }
+
+    void OnOK() override {
+        if (hasProgress_)
+            tsfn_.Release();
+        deferred_.Resolve(buildProcessResult(Env(), result_));
+    }
+
+    void OnError(const Napi::Error &e) override {
+        if (hasProgress_)
+            tsfn_.Release();
+        deferred_.Reject(e.Value());
+    }
+
+private:
+    std::string inputPath_;
+    ProcessingOptions opts_;
+    ProcessedWav result_;
+    Napi::Promise::Deferred deferred_;
+    Napi::ThreadSafeFunction tsfn_;
+    bool hasProgress_;
+};
+
+// ---------------------------------------------------------------------------
+// N-API exports
+// ---------------------------------------------------------------------------
+
+Napi::Value Process(const Napi::CallbackInfo &info) {
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 1 || !info[0].IsString())
+        throw Napi::TypeError::New(env, "Input path must be a string");
+
+    const std::string inputPath = info[0].As<Napi::String>();
+
+    ProcessingOptions opts;
+    if (info.Length() >= 2 && info[1].IsObject()) {
+        Napi::Object o = info[1].As<Napi::Object>();
+        if (o.Has("gain") && o.Get("gain").IsNumber())
+            opts.gain = o.Get("gain").As<Napi::Number>().DoubleValue();
+        if (o.Has("outputPath") && o.Get("outputPath").IsString())
+            opts.outputPath = o.Get("outputPath").As<Napi::String>().Utf8Value();
+    }
+
+    auto deferred = Napi::Promise::Deferred::New(env);
+    auto *worker = new ProcessWorker(env, inputPath, std::move(opts), deferred);
+
+    if (info.Length() >= 3 && info[2].IsFunction()) {
+        auto tsfn = Napi::ThreadSafeFunction::New(env, info[2].As<Napi::Function>(),
+                                                   "processProgress", 0, 1);
+        worker->setProgressCallback(std::move(tsfn));
+    }
+
+    worker->Queue();
+    return deferred.Promise();
+}
+
+Napi::Value Inspect(const Napi::CallbackInfo &info) {
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 1 || !info[0].IsString())
+        throw Napi::TypeError::New(env, "Input path must be a string");
+
+    const std::string inputPath = info[0].As<Napi::String>();
+
+    try {
+        std::ifstream file(inputPath, std::ios::binary);
+        if (!file.is_open())
+            throw dissonance::WavFormatError("Failed to open file: " + inputPath);
+
+        const Parser parser = Parser::fromFile(file, false);
+
+        Napi::Object listTags = Napi::Object::New(env);
+        if (auto it = parser.getOtherChunks().find("LIST"); it != parser.getOtherChunks().end()) {
+            const ListTags tags = parseListChunk(it->second);
+            listTags.Set("title", Napi::String::New(env, tags.title));
+            listTags.Set("artist", Napi::String::New(env, tags.artist));
+            listTags.Set("comment", Napi::String::New(env, tags.comment));
+            listTags.Set("date", Napi::String::New(env, tags.date));
+            listTags.Set("software", Napi::String::New(env, tags.software));
+            listTags.Set("genre", Napi::String::New(env, tags.genre));
+            listTags.Set("copyright", Napi::String::New(env, tags.copyright));
+        } else {
+            for (const char *k :
+                 {"title", "artist", "comment", "date", "software", "genre", "copyright"})
+                listTags.Set(k, Napi::String::New(env, ""));
+        }
+
+        Napi::Object result = Napi::Object::New(env);
+        result.Set("metadata", makeMetadataObject(env, parser));
+        result.Set("otherChunks", makeOtherChunks(env, parser));
+        result.Set("metadataText", Napi::String::New(env, formatMetadataText(parser)));
+        result.Set("listTags", listTags);
+        return result;
+    } catch (const std::exception &e) {
+        throw Napi::Error::New(env, e.what());
+    }
 }
 
 // --- Test/internal DSP exports ---
@@ -175,95 +334,6 @@ Napi::Value FFTMagnitude(const Napi::CallbackInfo &info) {
         return makeFloat32ArrayFromDouble(env, fft::magnitude(spectrum));
     } catch (const Napi::Error &) {
         throw;
-    } catch (const std::exception &e) {
-        throw Napi::Error::New(env, e.what());
-    }
-}
-
-Napi::Value Process(const Napi::CallbackInfo &info) {
-    Napi::Env env = info.Env();
-
-    if (info.Length() < 1 || !info[0].IsString())
-        throw Napi::TypeError::New(env, "Input path must be a string");
-
-    const std::string inputPath = info[0].As<Napi::String>();
-
-    ProcessingOptions opts;
-    if (info.Length() >= 2 && info[1].IsObject()) {
-        Napi::Object o = info[1].As<Napi::Object>();
-        if (o.Has("gain") && o.Get("gain").IsNumber())
-            opts.gain = o.Get("gain").As<Napi::Number>().DoubleValue();
-        if (o.Has("outputPath") && o.Get("outputPath").IsString())
-            opts.outputPath = o.Get("outputPath").As<Napi::String>().Utf8Value();
-    }
-
-    try {
-        const ProcessedWav processed = processWavFile(inputPath, opts);
-
-        Napi::Object listTags = Napi::Object::New(env);
-        listTags.Set("title", Napi::String::New(env, processed.listTags.title));
-        listTags.Set("artist", Napi::String::New(env, processed.listTags.artist));
-        listTags.Set("comment", Napi::String::New(env, processed.listTags.comment));
-        listTags.Set("date", Napi::String::New(env, processed.listTags.date));
-        listTags.Set("software", Napi::String::New(env, processed.listTags.software));
-        listTags.Set("genre", Napi::String::New(env, processed.listTags.genre));
-        listTags.Set("copyright", Napi::String::New(env, processed.listTags.copyright));
-
-        Napi::Object result = Napi::Object::New(env);
-        result.Set("metadata", makeMetadataObject(env, processed.parser));
-        result.Set("otherChunks", makeOtherChunks(env, processed.parser));
-        result.Set("metadataText", Napi::String::New(env, processed.metadataText));
-        result.Set("waveformText", Napi::String::New(env, processed.waveformText));
-        result.Set("listTags", listTags);
-        result.Set("processedPath", Napi::String::New(env, processed.processedPath));
-        result.Set("fftApplied", Napi::Boolean::New(env, processed.fftReport.applied));
-        result.Set("fftFramesProcessed",
-                   Napi::Number::New(env, processed.fftReport.framesProcessed));
-        result.Set("fftBins", Napi::Number::New(env, processed.fftReport.bins));
-        result.Set("fftCutoffBin", Napi::Number::New(env, processed.fftReport.cutoffBin));
-        return result;
-    } catch (const std::exception &e) {
-        throw Napi::Error::New(env, e.what());
-    }
-}
-
-Napi::Value Inspect(const Napi::CallbackInfo &info) {
-    Napi::Env env = info.Env();
-
-    if (info.Length() < 1 || !info[0].IsString())
-        throw Napi::TypeError::New(env, "Input path must be a string");
-
-    const std::string inputPath = info[0].As<Napi::String>();
-
-    try {
-        std::ifstream file(inputPath, std::ios::binary);
-        if (!file.is_open())
-            throw dissonance::WavFormatError("Failed to open file: " + inputPath);
-
-        const Parser parser = Parser::fromFile(file, false);
-
-        Napi::Object listTags = Napi::Object::New(env);
-        if (auto it = parser.getOtherChunks().find("LIST"); it != parser.getOtherChunks().end()) {
-            const ListTags tags = parseListChunk(it->second);
-            listTags.Set("title", Napi::String::New(env, tags.title));
-            listTags.Set("artist", Napi::String::New(env, tags.artist));
-            listTags.Set("comment", Napi::String::New(env, tags.comment));
-            listTags.Set("date", Napi::String::New(env, tags.date));
-            listTags.Set("software", Napi::String::New(env, tags.software));
-            listTags.Set("genre", Napi::String::New(env, tags.genre));
-            listTags.Set("copyright", Napi::String::New(env, tags.copyright));
-        } else {
-            for (const char *k :
-                 {"title", "artist", "comment", "date", "software", "genre", "copyright"})
-                listTags.Set(k, Napi::String::New(env, ""));
-        }
-
-        Napi::Object result = Napi::Object::New(env);
-        result.Set("metadata", makeMetadataObject(env, parser));
-        result.Set("otherChunks", makeOtherChunks(env, parser));
-        result.Set("metadataText", Napi::String::New(env, formatMetadataText(parser)));
-        result.Set("listTags", listTags);
-        return result;
     } catch (const std::exception &e) {
         throw Napi::Error::New(env, e.what());
     }

--- a/src/audio/WavProcessor.cpp
+++ b/src/audio/WavProcessor.cpp
@@ -79,6 +79,54 @@ ProcessedWav processWavFile(const std::string &inputPath, const ProcessingOption
     GainProcessor gainProcessor(opts.gain);
     gainProcessor.apply(result.processedSamples);
 
+    const uint16_t numChannels = parser.getNumChannels();
+    if (numChannels > 0 && !result.processedSamples.empty()) {
+        constexpr size_t frameSize = 2048;
+        constexpr size_t hopSize = 1024;
+        constexpr size_t cutoff = frameSize / 4;
+
+        const size_t totalFrames = result.processedSamples.size() / numChannels;
+
+        if (totalFrames >= 2) {
+            const std::vector<double> win = window::generate(window::Type::Hann, frameSize);
+
+            for (uint16_t ch = 0; ch < numChannels; ++ch) {
+                std::vector<float> output(totalFrames, 0.0f);
+                size_t hopIdx = 0;
+
+                for (size_t offset = 0; offset < totalFrames; offset += hopSize, ++hopIdx) {
+                    if (ch == 0 && opts.progressCallback && hopIdx % 16 == 0)
+                        opts.progressCallback(static_cast<float>(offset) /
+                                              static_cast<float>(totalFrames));
+
+                    std::vector<float> block(frameSize, 0.0f);
+                    const size_t available = std::min(frameSize, totalFrames - offset);
+                    for (size_t i = 0; i < available; ++i)
+                        block[i] = result.processedSamples[(offset + i) * numChannels + ch];
+
+                    window::apply(block, win);
+                    auto spectrum = fft::transform(block);
+
+                    for (size_t k = cutoff; k < spectrum.size(); ++k)
+                        spectrum[k] = {0.0, 0.0};
+
+                    auto reconstructed = fft::inverse(spectrum);
+                    for (size_t i = 0; i < frameSize && (offset + i) < totalFrames; ++i)
+                        output[offset + i] += static_cast<float>(reconstructed[i]);
+                }
+
+                for (size_t i = 0; i < totalFrames; ++i)
+                    result.processedSamples[i * numChannels + ch] =
+                        std::clamp(output[i], -1.0f, 1.0f);
+            }
+
+            if (opts.progressCallback)
+                opts.progressCallback(1.0f);
+
+            result.fftReport = {true, totalFrames, frameSize, cutoff};
+        }
+    }
+
     result.processedPath = makeOutputPath(inputPath, opts.outputPath);
     writeWavFile(parser, result.processedSamples, result.processedPath);
 
@@ -87,37 +135,6 @@ ProcessedWav processWavFile(const std::string &inputPath, const ProcessingOption
 
     if (auto it = result.otherChunks.find("LIST"); it != result.otherChunks.end())
         result.listTags = parseListChunk(it->second);
-
-    const uint16_t numChannels = parser.getNumChannels();
-    if (numChannels > 0 && !result.processedSamples.empty()) {
-        const size_t totalFrames = result.processedSamples.size() / numChannels;
-        const size_t framesToProcess = std::min<size_t>(totalFrames, 2048);
-
-        if (framesToProcess > 1) {
-            const std::vector<double> win = window::generate(window::Type::Hann, framesToProcess);
-
-            for (uint16_t ch = 0; ch < numChannels; ++ch) {
-                std::vector<float> block(framesToProcess);
-                for (size_t i = 0; i < framesToProcess; ++i)
-                    block[i] = result.processedSamples[i * numChannels + ch];
-
-                window::apply(block, win);
-
-                auto spectrum = fft::transform(block);
-
-                const size_t cutoff = spectrum.size() / 4;
-                for (size_t k = cutoff; k < spectrum.size(); ++k)
-                    spectrum[k] = {0.0, 0.0};
-
-                auto reconstructed = fft::inverse(spectrum);
-                for (size_t i = 0; i < framesToProcess; ++i)
-                    result.processedSamples[i * numChannels + ch] =
-                        std::clamp(static_cast<float>(reconstructed[i]), -1.0f, 1.0f);
-            }
-
-            result.fftReport = {true, framesToProcess, framesToProcess, framesToProcess / 4};
-        }
-    }
 
     return result;
 }

--- a/src/cli/Commands.cpp
+++ b/src/cli/Commands.cpp
@@ -4,11 +4,14 @@
 #include "audio/FFTProcessor.hpp"
 #include "audio/WindowFunctions.hpp"
 #include "core/Errors.hpp"
-#include <iostream>
-#include <fstream>
-#include <memory>
-#include <string>
+#include <algorithm>
 #include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <string>
 
 void Commands::printUsage(const char *programName) {
     std::cout << "Usage: " << programName << " <command> <input_file> [options]\n\n"
@@ -20,13 +23,14 @@ void Commands::printUsage(const char *programName) {
               << "  --offset <seconds>  Start offset into the file (default: 0)\n"
               << "  --bins <n>          Number of frequency bins to display (default: 16)\n"
               << "  --full              Average spectrum across entire file (Welch's method)\n"
+              << "  --sort              Sort displayed bins by magnitude (loudest first)\n"
               << "\nOptions for 'process':\n"
               << "  --gain <value>      Apply gain (default: 0.8)\n"
               << "  --output <path>     Output file path (default: <input>-processed.wav)\n"
               << "\nExamples:\n"
               << "  " << programName << " info sound.wav\n"
               << "  " << programName << " process sound.wav --gain 0.5 --output output.wav\n"
-              << "  " << programName << " fft sound.wav\n";
+              << "  " << programName << " fft sound.wav --full --sort\n";
 }
 
 int Commands::handleInfo(const std::string &inputPath) {
@@ -72,6 +76,7 @@ int Commands::handleFft(const std::string &inputPath, int argc, char **argv, int
     double offsetSecs = 0.0;
     size_t topBins = 16;
     bool fullFile = false;
+    bool sortByMag = false;
 
     for (int i = startIdx; i < argc; ++i) {
         if (std::string(argv[i]) == "--offset" && i + 1 < argc)
@@ -80,6 +85,8 @@ int Commands::handleFft(const std::string &inputPath, int argc, char **argv, int
             topBins = static_cast<size_t>(std::stoul(argv[++i]));
         else if (std::string(argv[i]) == "--full")
             fullFile = true;
+        else if (std::string(argv[i]) == "--sort")
+            sortByMag = true;
     }
 
     std::ifstream file(inputPath, std::ios::binary);
@@ -121,7 +128,6 @@ int Commands::handleFft(const std::string &inputPath, int argc, char **argv, int
             window::apply(blockF, win);
 
             auto mags = fft::magnitude(fft::transform(blockF));
-
             for (size_t k = 0; k < frameSize; ++k)
                 accumulated[k] += mags[k];
             ++windowCount;
@@ -152,18 +158,68 @@ int Commands::handleFft(const std::string &inputPath, int argc, char **argv, int
         windowCount = 1;
     }
 
-    std::cout << "\nFrequency resolution: " << (static_cast<double>(sampleRate) / frameSize)
-              << " Hz/bin\n\n";
+    // Normalize to per-window average — only use positive-frequency half
+    const size_t halfBins = frameSize / 2;
+    std::vector<double> mags(halfBins);
+    for (size_t k = 0; k < halfBins; ++k)
+        mags[k] = accumulated[k] / static_cast<double>(windowCount);
 
-    const size_t displayBins = std::min(topBins, frameSize / 2);
-    std::cout << "Top " << displayBins << " frequency bins:\n";
-    std::cout << "Bin\tFreq (Hz)\tMagnitude\n";
-    std::cout << "---\t---------\t---------\n";
+    // --- Summary stats ---
+    const size_t peakBin =
+        static_cast<size_t>(std::max_element(mags.begin() + 1, mags.end()) - mags.begin());
+    const double peakFreq = (static_cast<double>(peakBin) * sampleRate) / frameSize;
+    const double freqRes = static_cast<double>(sampleRate) / frameSize;
 
-    for (size_t i = 0; i < displayBins; ++i) {
-        double freq = (static_cast<double>(i) * sampleRate) / frameSize;
-        double mag = accumulated[i] / static_cast<double>(windowCount);
-        std::cout << i << "\t" << freq << "\t\t" << mag << "\n";
+    double sumMag = 0.0, sumWeighted = 0.0;
+    for (size_t k = 1; k < halfBins; ++k) {
+        double freq = static_cast<double>(k) * freqRes;
+        sumMag += mags[k];
+        sumWeighted += freq * mags[k];
+    }
+    const double centroid = (sumMag > 0.0) ? (sumWeighted / sumMag) : 0.0;
+    const double dcRatio = (mags[peakBin] > 0.0) ? (mags[0] / mags[peakBin]) : 0.0;
+
+    std::cout << "\n=== Spectrum Summary ===\n";
+    std::cout << std::fixed << std::setprecision(1);
+    printField("Peak frequency", std::to_string(static_cast<int>(std::round(peakFreq))) + " Hz" +
+                                     " (bin " + std::to_string(peakBin) + ")");
+    printField("Spectral centroid", std::to_string(static_cast<int>(std::round(centroid))) + " Hz");
+    if (dcRatio > 0.5)
+        printField("DC bias", "HIGH (" + std::to_string(static_cast<int>(dcRatio * 100)) +
+                                  "% of peak) — consider high-pass filtering");
+
+    // --- Build display list ---
+    std::vector<size_t> indices(std::min(topBins, halfBins));
+    if (sortByMag) {
+        std::vector<size_t> all(halfBins);
+        std::iota(all.begin(), all.end(), 0);
+        std::partial_sort(all.begin(), all.begin() + static_cast<ptrdiff_t>(indices.size()),
+                          all.end(), [&](size_t a, size_t b) { return mags[a] > mags[b]; });
+        std::copy(all.begin(), all.begin() + static_cast<ptrdiff_t>(indices.size()),
+                  indices.begin());
+    } else {
+        std::iota(indices.begin(), indices.end(), 0);
+    }
+
+    const double maxMag = *std::max_element(mags.begin(), mags.end());
+    constexpr int barWidth = 30;
+
+    std::cout << "\n"
+              << (sortByMag ? "Top" : "First") << " " << indices.size() << " frequency bins"
+              << (sortByMag ? " (sorted by magnitude)" : "") << ":\n";
+    std::cout << std::left << std::setw(5) << "Bin" << std::setw(12) << "Freq (Hz)" << std::setw(10)
+              << "Magnitude" << "Bar\n";
+    std::cout << std::string(5, '-') << std::string(12, '-') << std::string(10, '-')
+              << std::string(barWidth, '-') << "\n";
+
+    std::cout << std::fixed << std::setprecision(2);
+    for (size_t idx : indices) {
+        double freq = static_cast<double>(idx) * freqRes;
+        double mag = mags[idx];
+        int bars = (maxMag > 0.0) ? static_cast<int>(mag / maxMag * barWidth) : 0;
+
+        std::cout << std::left << std::setw(5) << idx << std::setw(12) << freq << std::setw(10)
+                  << mag << std::string(bars, '#') << "\n";
     }
 
     return EXIT_SUCCESS;

--- a/tests/fft_processor_test.cpp
+++ b/tests/fft_processor_test.cpp
@@ -5,10 +5,10 @@
 #include "audio/FFTProcessor.hpp"
 #include "core/Errors.hpp"
 
-constexpr double EPS = 1e-6;
+constexpr double EPS = 1e-5;
 
 TEST(FFTProcessorTest, ImpulseHasFlatSpectrum) {
-    std::vector<double> impulse = {1.0, 0.0, 0.0, 0.0};
+    std::vector<float> impulse = {1.0f, 0.0f, 0.0f, 0.0f};
     auto spectrum = fft::transform(impulse);
 
     ASSERT_EQ(spectrum.size(), impulse.size());
@@ -19,29 +19,29 @@ TEST(FFTProcessorTest, ImpulseHasFlatSpectrum) {
 }
 
 TEST(FFTProcessorTest, InverseReconstructsImpulse) {
-    std::vector<double> impulse = {1.0, 0.0, 0.0, 0.0};
+    std::vector<float> impulse = {1.0f, 0.0f, 0.0f, 0.0f};
     auto spectrum = fft::transform(impulse);
     auto time = fft::inverse(spectrum);
 
     ASSERT_EQ(time.size(), impulse.size());
     for (size_t i = 0; i < time.size(); ++i) {
-        EXPECT_NEAR(time[i], impulse[i], EPS);
+        EXPECT_NEAR(time[i], static_cast<double>(impulse[i]), EPS);
     }
 }
 
 TEST(FFTProcessorTest, RoundTripSignal) {
-    std::vector<double> signal = {0.0, 1.0, 0.0, -1.0};
+    std::vector<float> signal = {0.0f, 1.0f, 0.0f, -1.0f};
     auto spectrum = fft::transform(signal);
     auto time = fft::inverse(spectrum);
 
     ASSERT_EQ(time.size(), signal.size());
     for (size_t i = 0; i < time.size(); ++i) {
-        EXPECT_NEAR(time[i], signal[i], EPS);
+        EXPECT_NEAR(time[i], static_cast<double>(signal[i]), EPS);
     }
 }
 
 TEST(FFTProcessorTest, MagnitudeMatchesSize) {
-    std::vector<double> signal = {0.0, 1.0, 0.0, -1.0};
+    std::vector<float> signal = {0.0f, 1.0f, 0.0f, -1.0f};
     auto spectrum = fft::transform(signal);
     auto mags = fft::magnitude(spectrum);
 
@@ -49,7 +49,7 @@ TEST(FFTProcessorTest, MagnitudeMatchesSize) {
 }
 
 TEST(FFTProcessorTest, ThrowsOnEmptyInput) {
-    std::vector<double> emptyReal;
+    std::vector<float> emptyReal;
     std::vector<std::complex<double>> emptyComplex;
 
     EXPECT_THROW(fft::transform(emptyReal), dissonance::DspError);

--- a/tests/js/test-gain.js
+++ b/tests/js/test-gain.js
@@ -16,81 +16,88 @@ if (!fs.existsSync(testFile)) {
 
 console.log('Testing gain processing...\n');
 
-// Test 1: Default gain
-console.log('✓ Test 1: Default gain (0.8)');
-try {
-    const outputFile1 = path.join(path.dirname(testFile), 'sound-gain-0.8.wav');
-    const result1 = dissonanceCore.process(testFile, { outputPath: outputFile1 });
-    console.log(`  Processed file: ${result1.processedPath}`);
-    console.log(`  Metadata: ${result1.metadataText.split('\n')[0]}`);
-    console.log('  ✓ Default gain test passed\n');
-} catch (e) {
-    console.error('  ✗ Default gain test failed:', e.message, '\n');
-}
+async function run() {
+    // Test 1: Default gain
+    console.log('Test 1: Default gain (0.8)');
+    try {
+        const outputFile1 = path.join(path.dirname(testFile), 'sound-gain-0.8.wav');
+        const result1 = await dissonanceCore.process(testFile, { outputPath: outputFile1 });
+        console.log(`  Processed file: ${result1.processedPath}`);
+        console.log(`  Metadata: ${result1.metadataText.split('\n')[0]}`);
+        console.log('  Default gain test passed\n');
+    } catch (e) {
+        console.error('  Default gain test failed:', e.message, '\n');
+    }
 
-// Test 2: Custom gain (0.5) - comparing with default 0.8
-console.log('✓ Test 2: Custom gain (0.5)');
-try {
-    // Process with 0.8 first and save file size
-    const outputFile08 = path.join(path.dirname(testFile), 'sound-gain-0.8.wav');
-    const result08 = dissonanceCore.process(testFile, { gain: 0.8, outputPath: outputFile08 });
-    const buffer08 = fs.readFileSync(result08.processedPath);
-    
-    // Now process with 0.5
-    const outputFile05 = path.join(path.dirname(testFile), 'sound-gain-0.5.wav');
-    const result05 = dissonanceCore.process(testFile, { gain: 0.5, outputPath: outputFile05 });
-    const buffer05 = fs.readFileSync(result05.processedPath);
-    
-    console.log(`  File with 0.8 gain: ${buffer08.length} bytes`);
-    console.log(`  File with 0.5 gain: ${buffer05.length} bytes`);
-    
-    let foundSample = false;
-    for (let i = 44; i < Math.min(buffer08.length, buffer05.length) - 2; i += 2) {
-        const sample08 = buffer08.readInt16LE(i);
-        const sample05 = buffer05.readInt16LE(i);
-        
-        // Look for samples with meaningful amplitude
-        if (Math.abs(sample08) > 100 && Math.abs(sample05) > 50) {
-            const ratio = sample05 / sample08;
-            console.log(`  Sample at offset ${i}:`);
-            console.log(`    0.8 gain: ${sample08}`);
-            console.log(`    0.5 gain: ${sample05}`);
-            console.log(`    Ratio: ${ratio.toFixed(3)} (expected ~0.625 = 0.5/0.8)`);
-            console.log(`    Matches expected: ${Math.abs(ratio - 0.625) < 0.05 ? 'YES ✓' : 'NO ✗'}`);
-            foundSample = true;
-            break;
+    // Test 2: Custom gain (0.5)
+    console.log('Test 2: Custom gain (0.5)');
+    try {
+        const outputFile08 = path.join(path.dirname(testFile), 'sound-gain-0.8.wav');
+        const result08 = await dissonanceCore.process(testFile, { gain: 0.8, outputPath: outputFile08 });
+        const buffer08 = fs.readFileSync(result08.processedPath);
+
+        const outputFile05 = path.join(path.dirname(testFile), 'sound-gain-0.5.wav');
+        const result05 = await dissonanceCore.process(testFile, { gain: 0.5, outputPath: outputFile05 });
+        const buffer05 = fs.readFileSync(result05.processedPath);
+
+        console.log(`  File with 0.8 gain: ${buffer08.length} bytes`);
+        console.log(`  File with 0.5 gain: ${buffer05.length} bytes`);
+
+        let foundSample = false;
+        for (let i = 44; i < Math.min(buffer08.length, buffer05.length) - 2; i += 2) {
+            const sample08 = buffer08.readInt16LE(i);
+            const sample05 = buffer05.readInt16LE(i);
+
+            if (Math.abs(sample08) > 100 && Math.abs(sample05) > 50) {
+                const ratio = sample05 / sample08;
+                console.log(`  Sample at offset ${i}:`);
+                console.log(`    0.8 gain: ${sample08}`);
+                console.log(`    0.5 gain: ${sample05}`);
+                console.log(`    Ratio: ${ratio.toFixed(3)} (expected ~0.625 = 0.5/0.8)`);
+                console.log(`    Matches expected: ${Math.abs(ratio - 0.625) < 0.05 ? 'YES' : 'NO'}`);
+                foundSample = true;
+                break;
+            }
         }
+
+        if (!foundSample)
+            console.log('  Warning: could not find non-zero samples to verify gain\n');
+        else
+            console.log('  Custom gain test passed\n');
+    } catch (e) {
+        console.error('  Custom gain test failed:', e.message, '\n');
     }
-    
-    if (!foundSample) {
-        console.log('  ⚠ Warning: Could not find non-zero samples to verify gain\n');
-    } else {
-        console.log('  ✓ Custom gain test passed\n');
+
+    // Test 3: Gain = 1.0
+    console.log('Test 3: Gain = 1.0 (no modification)');
+    try {
+        const outputFile10 = path.join(path.dirname(testFile), 'sound-gain-1.0.wav');
+        const result3 = await dissonanceCore.process(testFile, { gain: 1.0, outputPath: outputFile10 });
+        console.log(`  Processed file: ${result3.processedPath}`);
+        console.log('  Gain 1.0 test passed\n');
+    } catch (e) {
+        console.error('  Gain 1.0 test failed:', e.message, '\n');
     }
-} catch (e) {
-    console.error('  ✗ Custom gain test failed:', e.message, '\n');
+
+    // Test 4: Progress callback
+    console.log('Test 4: Progress callback');
+    try {
+        const outputFile15 = path.join(path.dirname(testFile), 'sound-gain-1.5.wav');
+        let lastProgress = -1;
+        const result4 = await dissonanceCore.process(
+            testFile,
+            { gain: 1.5, outputPath: outputFile15 },
+            (progress) => { lastProgress = progress; }
+        );
+        console.log(`  Processed file: ${result4.processedPath}`);
+        console.log(`  Last progress value: ${lastProgress}`);
+        console.log(`  Progress callback fired: ${lastProgress >= 0 ? 'YES' : 'NO'}`);
+        console.log('  Progress callback test passed\n');
+    } catch (e) {
+        console.error('  Progress callback test failed:', e.message, '\n');
+    }
+
+    console.log('All tests completed!');
 }
 
-// Test 3: Gain = 1.0 (no change)
-console.log('✓ Test 3: Gain = 1.0 (no modification)');
-try {
-    const outputFile10 = path.join(path.dirname(testFile), 'sound-gain-1.0.wav');
-    const result3 = dissonanceCore.process(testFile, { gain: 1.0, outputPath: outputFile10 });
-    console.log(`  Processed file: ${result3.processedPath}`);
-    console.log('  ✓ Gain 1.0 test passed\n');
-} catch (e) {
-    console.error('  ✗ Gain 1.0 test failed:', e.message, '\n');
-}
-
-// Test 4: High gain (1.5)
-console.log('✓ Test 4: High gain (1.5)');
-try {
-    const outputFile15 = path.join(path.dirname(testFile), 'sound-gain-1.5.wav');
-    const result4 = dissonanceCore.process(testFile, { gain: 1.5, outputPath: outputFile15 });
-    console.log(`  Processed file: ${result4.processedPath}`);
-    console.log('  ✓ High gain test passed\n');
-} catch (e) {
-    console.error('  ✗ High gain test failed:', e.message, '\n');
-}
-
-console.log('All tests completed!');
+run().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

- processWavFile gains an optional progressCallback in ProcessingOptions, called every 16 hops during STFT
- STFT loop now runs across the entire file using frameSize=2048, hopSize=1024 (50% overlap, periodic Hann, COLA-compliant) — previously only the first 2048 frames were processed
- Fixed a bug where writeWavFile ran before the STFT, so output files only had gain applied; write now happens after all processing
- Process() in addon.cpp returns a Promise — work runs on the libuv thread pool via AsyncWorker; optional third argument wires a JS progress callback through ThreadSafeFunction
- JS test-gain.js updated to await the Promise and verify the progress callback fires

## Test plan

- [ ] CI cmake build + ctest pass
- [ ] CI clang-format check passes
- [ ] CI cppcheck passes
- [ ] node tests/js/test-gain.js all tests pass including progress callback
- [ ] process() return value is a Promise (typeof .then === function)