### PR TITLE
feat: validate addon export shape on load (Phase 7)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,20 @@
-module.exports = require("./build/Release/dissonance_core.node");
+const addon = require("./build/Release/dissonance_core.node");
+
+const REQUIRED = [
+  "process",
+  "inspect",
+  "fft",
+  "ifft",
+  "fftMagnitude",
+  "generateWindow",
+  "applyWindow",
+];
+
+const missing = REQUIRED.filter((k) => typeof addon[k] !== "function");
+if (missing.length) {
+  throw new Error(
+    `dissonance-core: missing exports: ${missing.join(", ")}`
+  );
+}
+
+module.exports = addon;


### PR DESCRIPTION
## Summary

- `index.js` now checks that all 7 expected exports (`process`, `inspect`, `fft`, `ifft`, `fftMagnitude`, `generateWindow`, `applyWindow`) are functions before exporting the addon
- Throws a descriptive error on load if any are missing, rather than crashing later at call time with a confusing `undefined is not a function`

## Test plan

- [ ] CI passes (no C++ changes, clang-format/cppcheck not involved)
- [ ] `node -e "require('.')"` succeeds when the addon is built
- [ ] If an export is manually removed and the addon rebuilt, the error message names the missing export(s)