### PR TITLE
feat: compute per-bin masking thresholds (issue #42)

### DIFF
--- a/include/audio/PsychoacousticModel.hpp
+++ b/include/audio/PsychoacousticModel.hpp
@@ -1,20 +1,44 @@
 #pragma once
 
-#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
 
 /**
- * @brief Psychoacoustic model providing Bark-scale critical band mapping.
+ * @brief Psychoacoustic model for computing per-bin masking thresholds.
  *
- * Maps FFT bin indices to 24 Bark critical bands (0..23) using the standard
- * Zwicker & Terhardt formula. Stateless — all methods are static.
+ * Maps FFT bins to 24 Bark critical bands, applies a triangular spreading
+ * function, and incorporates the absolute threshold of hearing (Terhardt 1979).
+ *
+ * The main entry point is computeThresholds(), which takes a magnitude spectrum
+ * and returns per-bin linear masking thresholds suitable for clamping
+ * perturbation magnitudes.
  */
 class PsychoacousticModel {
   public:
     /** @brief Number of Bark critical bands (0..23). */
     static constexpr size_t kNumBarkBands = 24;
+
+    // --- Threshold computation (main entry point) ---
+
+    /**
+     * @brief Compute per-bin masking thresholds for a single FFT frame.
+     *
+     * Accumulates energy per Bark band, applies triangular spreading,
+     * incorporates absolute threshold of hearing, and maps back to per-bin
+     * linear magnitude thresholds.
+     *
+     * @param magnitude  Magnitude spectrum (full frameSize bins, linear scale).
+     *                   Must have length == frameSize.
+     * @param sampleRate Sample rate in Hz.
+     * @param frameSize  FFT frame size in samples (must be even).
+     * @return Threshold vector (same size as magnitude, linear scale).
+     *         Each entry is the maximum allowed linear magnitude perturbation.
+     */
+    static std::vector<float> computeThresholds(const std::vector<float> &magnitude,
+                                                uint32_t sampleRate, size_t frameSize);
+
+    // --- Utility functions (public for testability / CLI) ---
 
     /** @brief Convert frequency in Hz to Bark-scale value. */
     static float hzToBark(float hz);
@@ -30,4 +54,35 @@ class PsychoacousticModel {
      * @return Bark band index in [0, kNumBarkBands - 1].
      */
     static size_t binToBarkBand(size_t binIndex, uint32_t sampleRate, size_t frameSize);
+
+    /**
+     * @brief Spreading function attenuation between two Bark values.
+     *
+     * Triangular approximation: +25 dB/Bark upward, -10 dB/Bark downward.
+     *
+     * @param maskerBark Bark value of the masker (source) band.
+     * @param targetBark Bark value of the target band.
+     * @return Attenuation in dB (always >= 0).
+     */
+    static float spreadingAttenuation(float maskerBark, float targetBark);
+
+    /**
+     * @brief Absolute threshold of hearing in dB SPL for a given frequency.
+     *
+     * Terhardt (1979) formula:
+     *   T(f) = 3.64*(f/1k)^(-0.8) - 6.5*exp(-0.6*(f/1k-3.3)^2) + 1e-3*(f/1k)^4
+     */
+    static float absoluteThresholdDb(float hz);
+
+  private:
+    /**
+     * @brief Apply triangular spreading across Bark bands.
+     *
+     * Convolves each band's energy (in dB) with the spreading function,
+     * taking the per-band maximum (peak-picking model).
+     *
+     * @param bandEnergiesDB 24-element vector of Bark band energies in dB.
+     * @return Spread masking threshold per band in dB SPL.
+     */
+    static std::vector<float> applySpreading(const std::vector<float> &bandEnergiesDB);
 };

--- a/src/audio/PsychoacousticModel.cpp
+++ b/src/audio/PsychoacousticModel.cpp
@@ -1,15 +1,31 @@
 /**
  * @file PsychoacousticModel.cpp
- * @brief Bark-scale critical band mapping implementation.
+ * @brief Psychoacoustic masking threshold computation.
  *
- * This file implements the Bark-scale frequency scale used in psychoacoustics.
- * It provides Hz-to-Bark conversion and FFT-bin-to-Bark-band mapping.
+ * Implements Bark-scale band mapping, triangular spreading function,
+ * absolute threshold of hearing (Terhardt 1979), and per-bin masking
+ * threshold computation.
  */
 
 #include "audio/PsychoacousticModel.hpp"
 
 #include <algorithm>
 #include <cmath>
+#include <numeric>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace {
+
+/** @brief Tiny epsilon to avoid log10(0) or division by zero. */
+constexpr float kEps = 1.0e-12f;
+
+/** @brief Reference dB level corresponding to linear magnitude 1.0 (full-scale). */
+constexpr float kRefDb = 90.0f;
+
+} // namespace
 
 // ============================================================================
 // Hz-to-Bark conversion
@@ -53,4 +69,112 @@ size_t PsychoacousticModel::binToBarkBand(size_t binIndex, uint32_t sampleRate, 
     if (band >= kNumBarkBands)
         band = kNumBarkBands - 1;
     return band;
+}
+
+// ============================================================================
+// Spreading function
+// ============================================================================
+
+float PsychoacousticModel::spreadingAttenuation(float maskerBark, float targetBark) {
+    const float dz = targetBark - maskerBark;
+    if (dz >= 0.0f) {
+        // Upward spread (target higher frequency than masker): +25 dB/Bark
+        return 25.0f * dz;
+    } else {
+        // Downward spread (target lower frequency than masker): -10 dB/Bark
+        return -10.0f * dz; // dz negative → positive attenuation
+    }
+}
+
+std::vector<float> PsychoacousticModel::applySpreading(const std::vector<float> &bandEnergiesDB) {
+    std::vector<float> spreadMask(kNumBarkBands, -kRefDb);
+
+    // Compute the Bark value at the center of each band
+    std::vector<float> barkCenters(kNumBarkBands);
+    for (size_t b = 0; b < kNumBarkBands; ++b) {
+        barkCenters[b] = hzToBark(barkBandCenters()[b]);
+    }
+
+    // For each target band, take the maximum mask contribution from every masker
+    for (size_t target = 0; target < kNumBarkBands; ++target) {
+        float maxMask = -kRefDb;
+
+        for (size_t masker = 0; masker < kNumBarkBands; ++masker) {
+            const float atten = spreadingAttenuation(barkCenters[masker], barkCenters[target]);
+            const float contribution = bandEnergiesDB[masker] - atten;
+            if (contribution > maxMask)
+                maxMask = contribution;
+        }
+
+        spreadMask[target] = maxMask;
+    }
+
+    return spreadMask;
+}
+
+// ============================================================================
+// Absolute threshold of hearing
+// ============================================================================
+
+float PsychoacousticModel::absoluteThresholdDb(float hz) {
+    // Terhardt (1979) absolute threshold of hearing
+    // Valid from ~20 Hz to ~20 kHz
+    const float f = hz / 1000.0f; // normalize to kHz
+    return 3.64f * std::pow(f, -0.8f) - 6.5f * std::exp(-0.6f * std::pow(f - 3.3f, 2.0f)) +
+           1.0e-3f * std::pow(f, 4.0f);
+}
+
+// ============================================================================
+// Compute per-bin masking thresholds
+// ============================================================================
+
+std::vector<float> PsychoacousticModel::computeThresholds(const std::vector<float> &magnitude,
+                                                          uint32_t sampleRate, size_t frameSize) {
+    if (magnitude.size() != frameSize)
+        return {}; // size mismatch
+
+    const size_t halfBins = frameSize / 2;
+
+    // ── Step 1: Accumulate energy per Bark band ──
+    std::vector<float> bandLinearEnergy(kNumBarkBands, 0.0f);
+    for (size_t i = 0; i <= halfBins; ++i) {
+        const size_t band = binToBarkBand(i, sampleRate, frameSize);
+        const float energy = magnitude[i] * magnitude[i];
+        bandLinearEnergy[band] += energy;
+    }
+
+    // Convert to dB
+    std::vector<float> bandEnergyDb(kNumBarkBands);
+    for (size_t b = 0; b < kNumBarkBands; ++b) {
+        const float e = std::max(bandLinearEnergy[b], kEps);
+        bandEnergyDb[b] = 10.0f * std::log10(e);
+    }
+
+    // ── Step 2: Apply spreading function ──
+    std::vector<float> spreadMaskDb = applySpreading(bandEnergyDb);
+
+    // ── Step 3: Combine with absolute threshold of hearing ──
+    for (size_t b = 0; b < kNumBarkBands; ++b) {
+        const float centerHz = barkBandCenters()[b];
+        const float absDb = absoluteThresholdDb(centerHz);
+        spreadMaskDb[b] = std::max(spreadMaskDb[b], absDb);
+    }
+
+    // ── Step 4: Map per-band thresholds back to per-bin linear magnitude ──
+    std::vector<float> thresholds(frameSize, 0.0f);
+    for (size_t i = 0; i <= halfBins; ++i) {
+        const size_t band = binToBarkBand(i, sampleRate, frameSize);
+        const float threshDb = spreadMaskDb[band];
+        const float threshLin = std::pow(10.0f, threshDb / 20.0f);
+
+        thresholds[i] = threshLin;
+
+        // Mirror to negative-frequency bin
+        if (i > 0 && i < halfBins)
+            thresholds[frameSize - i] = threshLin;
+        else if (i == halfBins)
+            thresholds[halfBins] = threshLin; // Nyquist bin
+    }
+
+    return thresholds;
 }

--- a/tests/psychoacoustic_model_test.cpp
+++ b/tests/psychoacoustic_model_test.cpp
@@ -68,4 +68,116 @@ TEST(PsychoacousticModelTest, BinToBarkBand_HighFreq) {
     EXPECT_EQ(band, PsychoacousticModel::kNumBarkBands - 1);
 }
 
+// ---------------------------------------------------------------------------
+// Spreading function
+// ---------------------------------------------------------------------------
+
+TEST(PsychoacousticModelTest, SpreadingAttenuation_Downward) {
+    // Target below masker → -10 dB/Bark: attenuation should be positive
+    // masker at 5 Bark, target at 3 Bark → dz = -2 → atten = -10 * (-2) = 20
+    float atten = PsychoacousticModel::spreadingAttenuation(5.0f, 3.0f);
+    EXPECT_FLOAT_EQ(atten, 20.0f);
+}
+
+TEST(PsychoacousticModelTest, SpreadingAttenuation_Upward) {
+    // Target above masker → +25 dB/Bark
+    // masker at 3 Bark, target at 5 Bark → dz = 2 → atten = 25 * 2 = 50
+    float atten = PsychoacousticModel::spreadingAttenuation(3.0f, 5.0f);
+    EXPECT_FLOAT_EQ(atten, 50.0f);
+}
+
+TEST(PsychoacousticModelTest, SpreadingAttenuation_SameBand) {
+    // Same band → zero attenuation
+    float atten = PsychoacousticModel::spreadingAttenuation(7.0f, 7.0f);
+    EXPECT_FLOAT_EQ(atten, 0.0f);
+}
+
+TEST(PsychoacousticModelTest, SpreadingAttenuation_Symmetric) {
+    // Attenuation should be direction-dependent (not symmetric)
+    float up = PsychoacousticModel::spreadingAttenuation(3.0f, 5.0f);   // +25 * 2
+    float down = PsychoacousticModel::spreadingAttenuation(5.0f, 3.0f); // -10 * -2
+    EXPECT_NE(up, down);
+    EXPECT_GT(up, down); // upward spread attenuates more
+}
+
+// ---------------------------------------------------------------------------
+// Absolute threshold of hearing
+// ---------------------------------------------------------------------------
+
+TEST(PsychoacousticModelTest, AbsoluteThresholdDb_KnownValues) {
+    // At 1 kHz, threshold should be around 0 dB (normalized reference)
+    float thresh1k = PsychoacousticModel::absoluteThresholdDb(1000.0f);
+    EXPECT_NEAR(thresh1k, 0.0f, 5.0f);
+
+    // At 4 kHz, threshold dips (ear most sensitive ~2-5 kHz)
+    float thresh4k = PsychoacousticModel::absoluteThresholdDb(4000.0f);
+    EXPECT_LT(thresh4k, thresh1k); // more sensitive (lower threshold)
+
+    // At 100 Hz, threshold should be higher (less sensitive at low frequencies)
+    float thresh100 = PsychoacousticModel::absoluteThresholdDb(100.0f);
+    EXPECT_GT(thresh100, thresh1k); // less sensitive
+}
+
+TEST(PsychoacousticModelTest, AbsoluteThresholdDb_NonNegativeAtExtremes) {
+    // Very low frequencies should not produce NaN or negative infinity
+    float thresh20 = PsychoacousticModel::absoluteThresholdDb(20.0f);
+    EXPECT_TRUE(std::isfinite(thresh20));
+
+    // Very high frequencies should be finite
+    float thresh20k = PsychoacousticModel::absoluteThresholdDb(20000.0f);
+    EXPECT_TRUE(std::isfinite(thresh20k));
+}
+
+// ---------------------------------------------------------------------------
+// Compute masking thresholds
+// ---------------------------------------------------------------------------
+
+TEST(PsychoacousticModelTest, ComputeThresholds_SizeMismatchReturnsEmpty) {
+    std::vector<float> mag = {1.0f, 0.5f, 0.25f}; // only 3 entries, frameSize=2048
+    auto thresholds = PsychoacousticModel::computeThresholds(mag, 44100, 2048);
+    EXPECT_TRUE(thresholds.empty());
+}
+
+TEST(PsychoacousticModelTest, ComputeThresholds_OutputSizeMatches) {
+    constexpr size_t frameSize = 256;
+    std::vector<float> mag(frameSize, 0.5f);
+    auto thresholds = PsychoacousticModel::computeThresholds(mag, 44100, frameSize);
+    EXPECT_EQ(thresholds.size(), frameSize);
+}
+
+TEST(PsychoacousticModelTest, ComputeThresholds_AllZero) {
+    constexpr size_t frameSize = 256;
+    std::vector<float> mag(frameSize, 0.0f);
+    auto thresholds = PsychoacousticModel::computeThresholds(mag, 44100, frameSize);
+    EXPECT_EQ(thresholds.size(), frameSize);
+    // With zero input, thresholds should revert to absolute threshold of hearing
+    // All entries should be finite and non-negative
+    for (size_t i = 0; i < thresholds.size(); ++i) {
+        EXPECT_TRUE(std::isfinite(thresholds[i]));
+        EXPECT_GE(thresholds[i], 0.0f);
+    }
+}
+
+TEST(PsychoacousticModelTest, ComputeThresholds_PureTone) {
+    constexpr size_t frameSize = 512;
+
+    // A single strong tone at bin 50 (~4307 Hz at 44100/512)
+    std::vector<float> mag(frameSize, 0.0f);
+    mag[50] = 1.0f;
+    // Mirror for symmetry
+    mag[frameSize - 50] = 1.0f;
+
+    auto thresholds = PsychoacousticModel::computeThresholds(mag, 44100, frameSize);
+    EXPECT_EQ(thresholds.size(), frameSize);
+
+    // The band containing bin 50 should have the highest threshold
+    // (most masking, most permissive)
+    float maxThresh = 0.0f;
+    for (float t : thresholds) {
+        if (t > maxThresh)
+            maxThresh = t;
+    }
+    EXPECT_GT(maxThresh, 0.01f);
+}
+
 } // namespace


### PR DESCRIPTION
-- Add spreading function (+25 dB/Bark up, -10 dB/Bark down), absolute threshold of hearing (Terhardt 1979), and computeThresholds() to PsychoacousticModel. The method accumulates energy per Bark band, applies spreading, combines with ATH, and maps back to per-bin linear thresholds with mirror symmetry.

-- 7 new tests cover spreading slopes, ATH frequency response, empty input handling, output sizing, zero-input fallback, and pure-tone masking profile.