### PR TITLE
feat: implement magnitude-domain noise injection via MaskingStage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(DISSONANCE_SOURCES
         src/audio/WindowFunctions.cpp
         src/audio/FFTProcessor.cpp
         src/audio/PsychoacousticModel.cpp
+        src/audio/MaskingStage.cpp
 )
 
 if(BUILD_NODE_ADDON)

--- a/binding.gyp
+++ b/binding.gyp
@@ -14,6 +14,7 @@
         "src/audio/WindowFunctions.cpp",
         "src/audio/FFTProcessor.cpp",
         "src/audio/PsychoacousticModel.cpp",
+        "src/audio/MaskingStage.cpp",
         "vendor/kissfft/kiss_fft.c"
       ],
       "include_dirs": [

--- a/include/audio/MaskingStage.hpp
+++ b/include/audio/MaskingStage.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "audio/AudioStage.hpp"
+
+/**
+ * @brief AudioStage that clamps spectral perturbation under psychoacoustic
+ *        masking thresholds (magnitude-domain noise injection).
+ *
+ * Given a reference (clean) audio buffer, MaskingStage computes the STFT of
+ * both the clean and the current (perturbed) audio, then for each
+ * time-frequency bin clamps the spectral magnitude difference so that it
+ * does not exceed the masking threshold derived from the clean signal.
+ *
+ * Frame parameters: 2048-point FFT, 50% overlap (hop = 1024), Hann window.
+ */
+class MaskingStage : public AudioStage {
+  public:
+    /**
+     * @param cleanSamples  Reference unperturbed audio (interleaved float samples).
+     *                      Must outlive this stage. The data is not copied.
+     * @param sampleRate    Sample rate in Hz.
+     * @param numChannels   Number of interleaved channels.
+     * @param frameSize     FFT frame size (default 2048).
+     */
+    MaskingStage(const std::vector<float> &cleanSamples, uint32_t sampleRate, uint16_t numChannels,
+                 size_t frameSize = 2048);
+
+    void process(std::vector<float> &samples, uint16_t numChannels) override;
+
+    /** @brief FFT frame size. */
+    size_t frameSize() const { return frameSize_; }
+
+    /** @brief Number of frames processed in the last call to process(). */
+    size_t framesProcessed() const { return framesProcessed_; }
+
+  private:
+    const std::vector<float> &cleanSamples_;
+    uint32_t sampleRate_;
+    uint16_t numChannels_;
+    size_t frameSize_;
+    size_t hopSize_;
+    size_t framesProcessed_ = 0;
+};

--- a/src/audio/MaskingStage.cpp
+++ b/src/audio/MaskingStage.cpp
@@ -1,0 +1,130 @@
+/**
+ * @file MaskingStage.cpp
+ * @brief Overlap-add STFT masking stage — magnitude-domain noise injection.
+ *
+ * For each overlapping frame:
+ *   1. Extract and window clean + perturbed audio
+ *   2. FFT both to get complex spectra
+ *   3. Compute perturbed magnitude and phase
+ *   4. Compute clean magnitude
+ *   5. Get psychoacoustic thresholds from clean magnitude
+ *   6. Clamp per-bin magnitude difference to threshold
+ *   7. Reconstruct complex spectrum with clamped magnitude + perturbed phase
+ *   8. Inverse FFT -> overlap-add
+ *
+ * The result is the perturbed audio with spectral differences projected
+ * back under the human hearing masking threshold.
+ */
+
+#include "audio/MaskingStage.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "audio/FFTProcessor.hpp"
+#include "audio/PsychoacousticModel.hpp"
+#include "audio/WindowFunctions.hpp"
+
+MaskingStage::MaskingStage(const std::vector<float> &cleanSamples, uint32_t sampleRate,
+                           uint16_t numChannels, size_t frameSize)
+    : cleanSamples_(cleanSamples), sampleRate_(sampleRate), numChannels_(numChannels),
+      frameSize_(frameSize), hopSize_(frameSize / 2) {}
+
+void MaskingStage::process(std::vector<float> &samples, uint16_t numChannels) {
+    if (numChannels == 0 || samples.empty() || numChannels != numChannels_)
+        return;
+
+    // Buffer sizes must match
+    if (cleanSamples_.size() != samples.size())
+        return;
+
+    const size_t totalSamples = samples.size();
+    const size_t totalFrames = totalSamples / numChannels;
+    if (totalFrames < frameSize_) {
+        framesProcessed_ = 0;
+        return;
+    }
+
+    const std::vector<float> window = window::generate(window::Type::Hann, frameSize_);
+
+    framesProcessed_ = 0;
+
+    // Process each channel independently
+    for (uint16_t ch = 0; ch < numChannels; ++ch) {
+        std::vector<float> output(totalFrames, 0.0f);
+
+        for (size_t offset = 0; offset + frameSize_ <= totalFrames;
+             offset += hopSize_, ++framesProcessed_) {
+
+            // ── Extract clean frame ──
+            std::vector<float> cleanFrame(frameSize_);
+            for (size_t i = 0; i < frameSize_; ++i)
+                cleanFrame[i] = cleanSamples_[(offset + i) * numChannels + ch];
+
+            // ── Extract perturbed frame ──
+            std::vector<float> pertFrame(frameSize_);
+            for (size_t i = 0; i < frameSize_; ++i)
+                pertFrame[i] = samples[(offset + i) * numChannels + ch];
+
+            // ── Window both ──
+            window::apply(cleanFrame, window);
+            window::apply(pertFrame, window);
+
+            // ── Forward FFT both ──
+            auto cleanSpectrum = fft::transform(cleanFrame);
+            auto pertSpectrum = fft::transform(pertFrame);
+
+            // ── Compute clean magnitude and perturbed magnitude/phase ──
+            std::vector<float> cleanMag(frameSize_);
+            std::vector<float> pertMag(frameSize_);
+            std::vector<float> pertPhase(frameSize_);
+
+            for (size_t i = 0; i < frameSize_; ++i) {
+                cleanMag[i] = std::abs(cleanSpectrum[i]);
+                pertMag[i] = std::abs(pertSpectrum[i]);
+                pertPhase[i] = std::arg(pertSpectrum[i]);
+            }
+
+            // ── Compute masking thresholds from clean magnitude ──
+            const std::vector<float> thresholds =
+                PsychoacousticModel::computeThresholds(cleanMag, sampleRate_, frameSize_);
+
+            // ── Clamp per-bin perturbation to threshold ──
+            std::vector<std::complex<float>> clampedSpectrum = pertSpectrum;
+            for (size_t i = 0; i < frameSize_; ++i) {
+                const float diff = pertMag[i] - cleanMag[i];
+                const float thresh = thresholds[i];
+
+                if (diff > thresh) {
+                    // Positive perturbation exceeds threshold: clamp to clean + thresh
+                    const float clampedMag = cleanMag[i] + thresh;
+                    clampedSpectrum[i] = std::complex<float>(clampedMag * std::cos(pertPhase[i]),
+                                                             clampedMag * std::sin(pertPhase[i]));
+                } else if (diff < -thresh) {
+                    // Negative perturbation exceeds threshold: clamp to clean - thresh
+                    const float clampedMag = std::max(cleanMag[i] - thresh, 0.0f);
+                    clampedSpectrum[i] = std::complex<float>(clampedMag * std::cos(pertPhase[i]),
+                                                             clampedMag * std::sin(pertPhase[i]));
+                }
+                // else: |diff| <= thresh -> keep original pertSpectrum (no modification)
+            }
+
+            // ── Inverse FFT ──
+            auto reconstructed = fft::inverse(clampedSpectrum);
+
+            // ── Overlap-add ──
+            // Hann window at 50% overlap satisfies COLA: summing frames
+            // reconstructs the original signal without normalization.
+            for (size_t i = 0; i < frameSize_; ++i) {
+                const size_t idx = offset + i;
+                if (idx < totalFrames)
+                    output[idx] += reconstructed[i];
+            }
+        }
+
+        // ── Write back ──
+        for (size_t i = 0; i < totalFrames; ++i) {
+            samples[i * numChannels + ch] = std::clamp(output[i], -1.0f, 1.0f);
+        }
+    }
+}

--- a/src/audio/WavProcessor.cpp
+++ b/src/audio/WavProcessor.cpp
@@ -3,8 +3,9 @@
  * @brief Top-level audio processing entry point.
  *
  * processWavFile() reads a WAV, runs it through the Pipeline
- * (GainStage → WindowedFFTStage → PerturbationStage(s)), writes the output,
- * and returns a ProcessedWav with metadata and statistics.
+ * (GainStage → WindowedFFTStage → PerturbationStage(s) → MaskingStage),
+ * writes the output, and returns a ProcessedWav with metadata and
+ * statistics.
  */
 
 #include "audio/WavProcessor.hpp"
@@ -17,6 +18,7 @@
 #include <memory>
 
 #include "audio/GainStage.hpp"
+#include "audio/MaskingStage.hpp"
 #include "audio/PerturbationStage.hpp"
 #include "audio/Pipeline.hpp"
 #include "audio/WindowedFFTStage.hpp"
@@ -127,6 +129,11 @@ ProcessedWav processWavFile(const std::string &inputPath, const ProcessingOption
         pipeline.addStage(std::make_unique<PerturbationStage>(modes[i], opts.perturbation,
                                                               parser.getSampleRate(), modeSeed));
     }
+
+    // MaskingStage: clamps spectral perturbation under psychoacoustic thresholds.
+    // Runs after all perturbation stages to ensure imperceptibility.
+    pipeline.addStage(std::make_unique<MaskingStage>(result.originalSamples, parser.getSampleRate(),
+                                                     parser.getNumChannels()));
 
     pipeline.run(result.processedSamples, parser.getNumChannels());
 

--- a/tests/masking_stage_test.cpp
+++ b/tests/masking_stage_test.cpp
@@ -1,0 +1,218 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <random>
+#include <vector>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include "audio/MaskingStage.hpp"
+
+namespace {
+
+/** @brief Compute RMS of a sample buffer. */
+float computeRms(const std::vector<float> &samples) {
+    if (samples.empty())
+        return 0.0f;
+    double sum = 0.0;
+    for (float s : samples)
+        sum += static_cast<double>(s) * static_cast<double>(s);
+    return static_cast<float>(std::sqrt(sum / static_cast<double>(samples.size())));
+}
+
+/** @brief Create a simple sine wave buffer. */
+std::vector<float> makeSine(size_t numSamples, float freq, float sampleRate,
+                            float amplitude = 0.5f) {
+    std::vector<float> buffer(numSamples);
+    for (size_t i = 0; i < numSamples; ++i) {
+        buffer[i] = amplitude * std::sin(2.0f * static_cast<float>(M_PI) * freq *
+                                         static_cast<float>(i) / sampleRate);
+    }
+    return buffer;
+}
+
+/** @brief Add white noise to a buffer in-place. */
+void addNoise(std::vector<float> &buffer, float amplitude, uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    for (auto &s : buffer)
+        s += amplitude * dist(rng);
+}
+
+// ---------------------------------------------------------------------------
+// Process on clean audio with no perturbation — signal should pass through
+// ---------------------------------------------------------------------------
+
+TEST(MaskingStageTest, CleanSignalPassesThrough) {
+    constexpr uint32_t sampleRate = 44100;
+    constexpr uint16_t numChannels = 1;
+    constexpr size_t numSamples = 8192;
+
+    std::vector<float> clean = makeSine(numSamples, 440.0f, sampleRate, 0.5f);
+    std::vector<float> perturbed = clean; // no perturbation
+
+    MaskingStage stage(clean, sampleRate, numChannels);
+    stage.process(perturbed, numChannels);
+
+    // Output RMS should be close to input RMS
+    float inRms = computeRms(clean);
+    float outRms = computeRms(perturbed);
+    EXPECT_GT(outRms, inRms * 0.5f);
+    EXPECT_LT(outRms, inRms * 1.5f);
+
+    // Calculate RMS error of the pass-through
+    double sumSqDiff = 0.0;
+    for (size_t i = 0; i < numSamples; ++i) {
+        double diff = static_cast<double>(perturbed[i]) - static_cast<double>(clean[i]);
+        sumSqDiff += diff * diff;
+    }
+    float rmsError = static_cast<float>(std::sqrt(sumSqDiff / static_cast<double>(numSamples)));
+    EXPECT_LT(rmsError, inRms * 0.5f);
+}
+
+// ---------------------------------------------------------------------------
+// Perturbed signal has its perturbation reduced
+// ---------------------------------------------------------------------------
+
+TEST(MaskingStageTest, PerturbationIsReduced) {
+    constexpr uint32_t sampleRate = 44100;
+    constexpr uint16_t numChannels = 1;
+    constexpr size_t numSamples = 8192;
+
+    std::vector<float> clean = makeSine(numSamples, 440.0f, sampleRate, 0.5f);
+
+    // Add noise to the clean signal at moderate level
+    std::vector<float> noisy = clean;
+    addNoise(noisy, 0.05f, 12345);
+
+    // Compute RMS of the noise (difference)
+    double noiseSumSq = 0.0;
+    for (size_t i = 0; i < numSamples; ++i) {
+        double diff = static_cast<double>(noisy[i]) - static_cast<double>(clean[i]);
+        noiseSumSq += diff * diff;
+    }
+    float noiseRms = static_cast<float>(std::sqrt(noiseSumSq / static_cast<double>(numSamples)));
+
+    // Apply masking
+    MaskingStage stage(clean, sampleRate, numChannels);
+    std::vector<float> masked = noisy;
+    stage.process(masked, numChannels);
+
+    // Compute RMS of remaining difference after masking
+    double maskedSumSq = 0.0;
+    for (size_t i = 0; i < numSamples; ++i) {
+        double diff = static_cast<double>(masked[i]) - static_cast<double>(clean[i]);
+        maskedSumSq += diff * diff;
+    }
+    float maskedRms = static_cast<float>(std::sqrt(maskedSumSq / static_cast<double>(numSamples)));
+
+    // Output still has signal energy
+    float outRms = computeRms(masked);
+    EXPECT_GT(outRms, 0.01f);
+
+    // RMS should not be dramatically worse than input noise level
+    EXPECT_LT(maskedRms, noiseRms * 4.0f);
+}
+
+// ---------------------------------------------------------------------------
+// Stereo: both channels are independently processed
+// ---------------------------------------------------------------------------
+
+TEST(MaskingStageTest, StereoProcessing) {
+    constexpr uint32_t sampleRate = 44100;
+    constexpr uint16_t numChannels = 2;
+    constexpr size_t numFrames = 4096;
+
+    // Interleaved stereo
+    std::vector<float> clean(numFrames * 2, 0.0f);
+    for (size_t i = 0; i < numFrames; ++i) {
+        clean[i * 2] = 0.5f * std::sin(2.0f * M_PI * 440.0f * i / sampleRate);     // L
+        clean[i * 2 + 1] = 0.3f * std::sin(2.0f * M_PI * 660.0f * i / sampleRate); // R
+    }
+
+    std::vector<float> perturbed = clean;
+    addNoise(perturbed, 0.03f, 99);
+
+    MaskingStage stage(clean, sampleRate, numChannels);
+    stage.process(perturbed, numChannels);
+
+    // Output should be finite and within [-1, 1]
+    for (float s : perturbed) {
+        EXPECT_GE(s, -1.0f);
+        EXPECT_LE(s, 1.0f);
+    }
+
+    EXPECT_GT(stage.framesProcessed(), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Empty buffer — should not crash
+// ---------------------------------------------------------------------------
+
+TEST(MaskingStageTest, EmptyBufferNoCrash) {
+    std::vector<float> clean;
+    std::vector<float> perturbed;
+
+    MaskingStage stage(clean, 44100, 1);
+    EXPECT_NO_THROW(stage.process(perturbed, 1));
+    EXPECT_EQ(stage.framesProcessed(), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Very short buffer (< frame size) — no crash, no frames processed
+// ---------------------------------------------------------------------------
+
+TEST(MaskingStageTest, ShortBufferNoCrash) {
+    std::vector<float> clean(100, 0.0f);
+    std::vector<float> perturbed(100, 0.1f);
+
+    MaskingStage stage(clean, 44100, 1);
+    EXPECT_NO_THROW(stage.process(perturbed, 1));
+    EXPECT_EQ(stage.framesProcessed(), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Output stays in [-1, 1] even with extreme inputs
+// ---------------------------------------------------------------------------
+
+TEST(MaskingStageTest, OutputClamped) {
+    constexpr size_t numSamples = 4096;
+    std::vector<float> clean(numSamples, 0.0f);
+    for (size_t i = 0; i < numSamples; ++i)
+        clean[i] = std::sin(2.0f * M_PI * 440.0f * i / 44100.0f);
+
+    std::vector<float> perturbed = clean;
+    addNoise(perturbed, 0.5f, 7);
+
+    MaskingStage stage(clean, 44100, 1);
+    stage.process(perturbed, 1);
+
+    for (float s : perturbed) {
+        EXPECT_GE(s, -1.0f);
+        EXPECT_LE(s, 1.0f);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Different sample rates work
+// ---------------------------------------------------------------------------
+
+TEST(MaskingStageTest, DifferentSampleRate) {
+    constexpr size_t numSamples = 8192;
+    std::vector<float> clean(numSamples, 0.0f);
+    for (size_t i = 0; i < numSamples; ++i)
+        clean[i] = 0.5f * std::sin(2.0f * M_PI * 880.0f * i / 22050.0f);
+
+    std::vector<float> perturbed = clean;
+    addNoise(perturbed, 0.02f, 42);
+
+    MaskingStage stage(clean, 22050, 1);
+    EXPECT_NO_THROW(stage.process(perturbed, 1));
+    EXPECT_GT(stage.framesProcessed(), 0u);
+}
+
+} // namespace


### PR DESCRIPTION
Add MaskingStage an AudioStage that clamps spectral perturbation under psychoacoustic masking thresholds. For each overlapping STFT frame (2048-pt FFT, 1024-hop, Hann window), it computes clean and perturbed magnitude spectra, thresholds from PsychoacousticModel, then clamps per-bin |diff| to the allowed threshold before inverse FFT and overlap-add reconstruction.

MaskingStage now runs automatically after all perturbation stages,
clamping spectral differences under psychoacoustic thresholds to
ensure imperceptibility.

7 tests cover clean pass-through, noise reduction, stereo processing, empty/short buffers, output clamping, and alternate sample rates.