### PR TITLE
86 ath override in computethresholds lets noise through

### DIFF
--- a/include/audio/MaskingStage.hpp
+++ b/include/audio/MaskingStage.hpp
@@ -20,14 +20,15 @@
 class MaskingStage : public AudioStage {
   public:
     /**
-     * @param cleanSamples  Reference unperturbed audio (interleaved float samples).
-     *                      Must outlive this stage. The data is not copied.
-     * @param sampleRate    Sample rate in Hz.
-     * @param numChannels   Number of interleaved channels.
-     * @param frameSize     FFT frame size (default 2048).
+     * @param cleanSamples     Reference unperturbed audio (interleaved float samples).
+     *                         Must outlive this stage. The data is not copied.
+     * @param sampleRate       Sample rate in Hz.
+     * @param numChannels      Number of interleaved channels.
+     * @param maskingStrength  Threshold scale factor. 1 = normal, 0 = clamp all.
+     * @param frameSize        FFT frame size (default 2048).
      */
     MaskingStage(const std::vector<float> &cleanSamples, uint32_t sampleRate, uint16_t numChannels,
-                 size_t frameSize = 2048);
+                 float maskingStrength, size_t frameSize = 2048);
 
     void process(std::vector<float> &samples, uint16_t numChannels) override;
 
@@ -43,5 +44,6 @@ class MaskingStage : public AudioStage {
     uint16_t numChannels_;
     size_t frameSize_;
     size_t hopSize_;
+    float maskingStrength_;
     size_t framesProcessed_ = 0;
 };

--- a/include/audio/PsychoacousticModel.hpp
+++ b/include/audio/PsychoacousticModel.hpp
@@ -7,8 +7,8 @@
 /**
  * @brief Psychoacoustic model for computing per-bin masking thresholds.
  *
- * Maps FFT bins to 24 Bark critical bands, applies a triangular spreading
- * function, and incorporates the absolute threshold of hearing (Terhardt 1979).
+ * Maps FFT bins to 24 Bark critical bands and applies a triangular spreading
+ * function.
  *
  * The main entry point is computeThresholds(), which takes a magnitude spectrum
  * and returns per-bin linear masking thresholds suitable for clamping
@@ -24,9 +24,8 @@ class PsychoacousticModel {
     /**
      * @brief Compute per-bin masking thresholds for a single FFT frame.
      *
-     * Accumulates energy per Bark band, applies triangular spreading,
-     * incorporates absolute threshold of hearing, and maps back to per-bin
-     * linear magnitude thresholds.
+     * Accumulates energy per Bark band, applies triangular spreading, floors
+     * the result, and maps back to per-bin linear magnitude thresholds.
      *
      * @param magnitude  Magnitude spectrum (full frameSize bins, linear scale).
      *                   Must have length == frameSize.
@@ -58,21 +57,16 @@ class PsychoacousticModel {
     /**
      * @brief Spreading function attenuation between two Bark values.
      *
-     * Triangular approximation: +25 dB/Bark upward, -10 dB/Bark downward.
+     * Triangular approximation of the "upward spread of masking": a masker
+     * suppresses content above its own frequency more effectively than
+     * below it, so the upward slope (~10 dB/Bark) is gentler than the
+     * downward slope (~25 dB/Bark).
      *
      * @param maskerBark Bark value of the masker (source) band.
      * @param targetBark Bark value of the target band.
      * @return Attenuation in dB (always >= 0).
      */
     static float spreadingAttenuation(float maskerBark, float targetBark);
-
-    /**
-     * @brief Absolute threshold of hearing in dB SPL for a given frequency.
-     *
-     * Terhardt (1979) formula:
-     *   T(f) = 3.64*(f/1k)^(-0.8) - 6.5*exp(-0.6*(f/1k-3.3)^2) + 1e-3*(f/1k)^4
-     */
-    static float absoluteThresholdDb(float hz);
 
   private:
     /**

--- a/include/audio/WavProcessor.hpp
+++ b/include/audio/WavProcessor.hpp
@@ -21,9 +21,10 @@ struct ProcessingOptions {
     double gain = 0.8;         ///< Linear amplitude gain applied after FFT filtering.
     float perturbation = 0.5f; ///< Per-mode noise strength multiplier in [0, 1].
     std::vector<std::string>
-        perturbationModes;  ///< Modes to apply, e.g. {"white_noise","phase_distortion"}. Empty = no
-                            ///< perturbation.
-    std::string outputPath; ///< Output file path. Auto-generated if empty.
+        perturbationModes; ///< Modes to apply, e.g. {"white_noise","phase_distortion"}. Empty = no
+                           ///< perturbation.
+    float maskingStrength = 1.0f; ///< Masking threshold scale. 1 = psychoacoustic, 0 = clamp all.
+    std::string outputPath;       ///< Output file path. Auto-generated if empty.
     std::function<void(float)> progressCallback; ///< Optional progress callback in [0, 1].
 };
 

--- a/src/addon/addon.cpp
+++ b/src/addon/addon.cpp
@@ -57,6 +57,7 @@ class ProcessWorker : public Napi::AsyncWorker {
 // process(inputPath: string, options?: {
 //   outputPath?: string,
 //   perturbation?: number,
+//   maskingStrength?: number,
 //   modes?: string[]
 // })
 //   inputPath              – WAV file to process (required)
@@ -86,6 +87,11 @@ Napi::Value Process(const Napi::CallbackInfo &info) {
             Napi::Value v = jsOpts.Get("perturbation");
             if (v.IsNumber())
                 opts.perturbation = static_cast<float>(v.As<Napi::Number>().DoubleValue());
+        }
+        if (jsOpts.Has("maskingStrength")) {
+            Napi::Value v = jsOpts.Get("maskingStrength");
+            if (v.IsNumber())
+                opts.maskingStrength = static_cast<float>(v.As<Napi::Number>().DoubleValue());
         }
         if (jsOpts.Has("modes") && jsOpts.Get("modes").IsArray()) {
             Napi::Array modes = jsOpts.Get("modes").As<Napi::Array>();

--- a/src/audio/MaskingStage.cpp
+++ b/src/audio/MaskingStage.cpp
@@ -91,8 +91,8 @@ void MaskingStage::process(std::vector<float> &samples, uint16_t numChannels) {
 
             // ── Scale thresholds by masking strength ──
             if (maskingStrength_ < 1.0f) {
-                for (auto &t : thresholds)
-                    t *= maskingStrength_;
+                std::transform(thresholds.begin(), thresholds.end(), thresholds.begin(),
+                               [this](float t) { return t * maskingStrength_; });
             }
 
             // ── Clamp per-bin perturbation to threshold ──

--- a/src/audio/MaskingStage.cpp
+++ b/src/audio/MaskingStage.cpp
@@ -26,9 +26,9 @@
 #include "audio/WindowFunctions.hpp"
 
 MaskingStage::MaskingStage(const std::vector<float> &cleanSamples, uint32_t sampleRate,
-                           uint16_t numChannels, size_t frameSize)
+                           uint16_t numChannels, float maskingStrength, size_t frameSize)
     : cleanSamples_(cleanSamples), sampleRate_(sampleRate), numChannels_(numChannels),
-      frameSize_(frameSize), hopSize_(frameSize / 2) {}
+      frameSize_(frameSize), hopSize_(frameSize / 2), maskingStrength_(maskingStrength) {}
 
 void MaskingStage::process(std::vector<float> &samples, uint16_t numChannels) {
     if (numChannels == 0 || samples.empty() || numChannels != numChannels_)
@@ -86,8 +86,14 @@ void MaskingStage::process(std::vector<float> &samples, uint16_t numChannels) {
             }
 
             // ── Compute masking thresholds from clean magnitude ──
-            const std::vector<float> thresholds =
+            std::vector<float> thresholds =
                 PsychoacousticModel::computeThresholds(cleanMag, sampleRate_, frameSize_);
+
+            // ── Scale thresholds by masking strength ──
+            if (maskingStrength_ < 1.0f) {
+                for (auto &t : thresholds)
+                    t *= maskingStrength_;
+            }
 
             // ── Clamp per-bin perturbation to threshold ──
             std::vector<std::complex<float>> clampedSpectrum = pertSpectrum;

--- a/src/audio/PsychoacousticModel.cpp
+++ b/src/audio/PsychoacousticModel.cpp
@@ -2,9 +2,8 @@
  * @file PsychoacousticModel.cpp
  * @brief Psychoacoustic masking threshold computation.
  *
- * Implements Bark-scale band mapping, triangular spreading function,
- * absolute threshold of hearing (Terhardt 1979), and per-bin masking
- * threshold computation.
+ * Implements Bark-scale band mapping, triangular spreading function, and
+ * per-bin masking threshold computation.
  */
 
 #include "audio/PsychoacousticModel.hpp"
@@ -78,11 +77,16 @@ size_t PsychoacousticModel::binToBarkBand(size_t binIndex, uint32_t sampleRate, 
 float PsychoacousticModel::spreadingAttenuation(float maskerBark, float targetBark) {
     const float dz = targetBark - maskerBark;
     if (dz >= 0.0f) {
-        // Upward spread (target higher frequency than masker): +25 dB/Bark
-        return 25.0f * dz;
+        // Upward spread (target higher frequency than masker): the "upward
+        // spread of masking" phenomenon — a masker suppresses content above
+        // its own frequency more effectively than below it, so this slope
+        // must be the gentler one (~10 dB/Bark) for loud low/mid content to
+        // actually mask noise sitting above it in frequency.
+        return 10.0f * dz;
     } else {
-        // Downward spread (target lower frequency than masker): -10 dB/Bark
-        return -10.0f * dz; // dz negative → positive attenuation
+        // Downward spread (target lower frequency than masker): falls off
+        // faster below the masker — steeper slope, ~25 dB/Bark.
+        return -25.0f * dz; // dz negative → positive attenuation
     }
 }
 
@@ -113,18 +117,6 @@ std::vector<float> PsychoacousticModel::applySpreading(const std::vector<float> 
 }
 
 // ============================================================================
-// Absolute threshold of hearing
-// ============================================================================
-
-float PsychoacousticModel::absoluteThresholdDb(float hz) {
-    // Terhardt (1979) absolute threshold of hearing
-    // Valid from ~20 Hz to ~20 kHz
-    const float f = hz / 1000.0f; // normalize to kHz
-    return 3.64f * std::pow(f, -0.8f) - 6.5f * std::exp(-0.6f * std::pow(f - 3.3f, 2.0f)) +
-           1.0e-3f * std::pow(f, 4.0f);
-}
-
-// ============================================================================
 // Compute per-bin masking thresholds
 // ============================================================================
 
@@ -135,29 +127,51 @@ std::vector<float> PsychoacousticModel::computeThresholds(const std::vector<floa
 
     const size_t halfBins = frameSize / 2;
 
-    // ── Step 1: Accumulate energy per Bark band ──
+    // ── Step 1: Accumulate average per-bin energy per Bark band ──
+    // Bark bands vary hugely in width — 5 bins in the lowest band vs. ~500
+    // bins in the top band at a 2048-sample frame. Summing raw energy across
+    // a band and reusing that sum as the per-bin threshold (Step 4) scales
+    // the allowance with bin count: a wide band ends up with a threshold
+    // ~sqrt(binCount) times larger than any individual bin's real magnitude
+    // justifies, letting far more noise through per-bin in wide bands. This
+    // is most visible with high-frequency noise (e.g. white_noise's 8 kHz
+    // high-pass), which lands almost entirely in the widest top bands.
+    // Averaging keeps the threshold representative of a single bin.
     std::vector<float> bandLinearEnergy(kNumBarkBands, 0.0f);
+    std::vector<size_t> bandBinCount(kNumBarkBands, 0);
     for (size_t i = 0; i <= halfBins; ++i) {
         const size_t band = binToBarkBand(i, sampleRate, frameSize);
         const float energy = magnitude[i] * magnitude[i];
         bandLinearEnergy[band] += energy;
+        ++bandBinCount[band];
     }
 
-    // Convert to dB
+    // Convert average per-bin energy to dB
     std::vector<float> bandEnergyDb(kNumBarkBands);
     for (size_t b = 0; b < kNumBarkBands; ++b) {
-        const float e = std::max(bandLinearEnergy[b], kEps);
+        const float avgEnergy =
+            bandBinCount[b] > 0 ? bandLinearEnergy[b] / static_cast<float>(bandBinCount[b]) : 0.0f;
+        const float e = std::max(avgEnergy, kEps);
         bandEnergyDb[b] = 10.0f * std::log10(e);
     }
 
     // ── Step 2: Apply spreading function ──
     std::vector<float> spreadMaskDb = applySpreading(bandEnergyDb);
 
-    // ── Step 3: Combine with absolute threshold of hearing ──
+    // ── Step 3: Apply minimum threshold floor ──
+    // ATH is intentionally not used as an absolute comparison here.
+    // The ATH values are in dB SPL but our signal energies are in an
+    // uncalibrated dB scale from raw FFT magnitudes — comparing them
+    // directly lets the ATH override the spreading function in quiet
+    // bands, letting noise through (the bug you can hear).
+    //
+    // For perturbation clamping, the spreading function alone provides
+    // correct behavior: bands near the signal have high thresholds (noise
+    // is masked), bands far from the signal have low thresholds (noise is
+    // clamped). A conservative floor prevents numerical issues.
+    constexpr float kMinThresholdDb = -80.0f;
     for (size_t b = 0; b < kNumBarkBands; ++b) {
-        const float centerHz = barkBandCenters()[b];
-        const float absDb = absoluteThresholdDb(centerHz);
-        spreadMaskDb[b] = std::max(spreadMaskDb[b], absDb);
+        spreadMaskDb[b] = std::max(spreadMaskDb[b], kMinThresholdDb);
     }
 
     // ── Step 4: Map per-band thresholds back to per-bin linear magnitude ──

--- a/src/audio/WavProcessor.cpp
+++ b/src/audio/WavProcessor.cpp
@@ -133,7 +133,8 @@ ProcessedWav processWavFile(const std::string &inputPath, const ProcessingOption
     // MaskingStage: clamps spectral perturbation under psychoacoustic thresholds.
     // Runs after all perturbation stages to ensure imperceptibility.
     pipeline.addStage(std::make_unique<MaskingStage>(result.originalSamples, parser.getSampleRate(),
-                                                     parser.getNumChannels()));
+                                                     parser.getNumChannels(),
+                                                     opts.maskingStrength));
 
     pipeline.run(result.processedSamples, parser.getNumChannels());
 

--- a/src/cli/Commands.cpp
+++ b/src/cli/Commands.cpp
@@ -36,6 +36,8 @@ void Commands::printUsage(const char *programName) {
               << "\nOptions for 'process':\n"
               << "  --gain <value>          Apply gain (default: 0.8)\n"
               << "  --perturbation <0..1>   Per-mode noise strength (default: 0.5)\n"
+              << "  --masking-strength <0..1> Masking threshold scale, lower = more clamping "
+                 "(default: 1.0)\n"
               << "  --mode <name>           Perturbation mode (";
     bool first = true;
     const std::vector<std::string> knownModes = {"white_noise", "phase_distortion", "spectral_gate",
@@ -81,6 +83,8 @@ int Commands::handleProcess(const std::string &inputPath, int argc, char **argv,
             opts.perturbationModes.push_back(argv[++i]);
         } else if (std::string(argv[i]) == "--output" && i + 1 < argc) {
             opts.outputPath = argv[++i];
+        } else if (std::string(argv[i]) == "--masking-strength" && i + 1 < argc) {
+            opts.maskingStrength = static_cast<float>(std::stod(argv[++i]));
         }
     }
 

--- a/tests/masking_stage_test.cpp
+++ b/tests/masking_stage_test.cpp
@@ -55,7 +55,7 @@ TEST(MaskingStageTest, CleanSignalPassesThrough) {
     std::vector<float> clean = makeSine(numSamples, 440.0f, sampleRate, 0.5f);
     std::vector<float> perturbed = clean; // no perturbation
 
-    MaskingStage stage(clean, sampleRate, numChannels);
+    MaskingStage stage(clean, sampleRate, numChannels, 1.0f);
     stage.process(perturbed, numChannels);
 
     // Output RMS should be close to input RMS
@@ -98,7 +98,7 @@ TEST(MaskingStageTest, PerturbationIsReduced) {
     float noiseRms = static_cast<float>(std::sqrt(noiseSumSq / static_cast<double>(numSamples)));
 
     // Apply masking
-    MaskingStage stage(clean, sampleRate, numChannels);
+    MaskingStage stage(clean, sampleRate, numChannels, 1.0f);
     std::vector<float> masked = noisy;
     stage.process(masked, numChannels);
 
@@ -137,7 +137,7 @@ TEST(MaskingStageTest, StereoProcessing) {
     std::vector<float> perturbed = clean;
     addNoise(perturbed, 0.03f, 99);
 
-    MaskingStage stage(clean, sampleRate, numChannels);
+    MaskingStage stage(clean, sampleRate, numChannels, 1.0f);
     stage.process(perturbed, numChannels);
 
     // Output should be finite and within [-1, 1]
@@ -157,7 +157,7 @@ TEST(MaskingStageTest, EmptyBufferNoCrash) {
     std::vector<float> clean;
     std::vector<float> perturbed;
 
-    MaskingStage stage(clean, 44100, 1);
+    MaskingStage stage(clean, 44100, 1, 1.0f);
     EXPECT_NO_THROW(stage.process(perturbed, 1));
     EXPECT_EQ(stage.framesProcessed(), 0u);
 }
@@ -170,7 +170,7 @@ TEST(MaskingStageTest, ShortBufferNoCrash) {
     std::vector<float> clean(100, 0.0f);
     std::vector<float> perturbed(100, 0.1f);
 
-    MaskingStage stage(clean, 44100, 1);
+    MaskingStage stage(clean, 44100, 1, 1.0f);
     EXPECT_NO_THROW(stage.process(perturbed, 1));
     EXPECT_EQ(stage.framesProcessed(), 0u);
 }
@@ -188,7 +188,7 @@ TEST(MaskingStageTest, OutputClamped) {
     std::vector<float> perturbed = clean;
     addNoise(perturbed, 0.5f, 7);
 
-    MaskingStage stage(clean, 44100, 1);
+    MaskingStage stage(clean, 44100, 1, 1.0f);
     stage.process(perturbed, 1);
 
     for (float s : perturbed) {
@@ -210,7 +210,7 @@ TEST(MaskingStageTest, DifferentSampleRate) {
     std::vector<float> perturbed = clean;
     addNoise(perturbed, 0.02f, 42);
 
-    MaskingStage stage(clean, 22050, 1);
+    MaskingStage stage(clean, 22050, 1, 1.0f);
     EXPECT_NO_THROW(stage.process(perturbed, 1));
     EXPECT_GT(stage.framesProcessed(), 0u);
 }

--- a/tests/psychoacoustic_model_test.cpp
+++ b/tests/psychoacoustic_model_test.cpp
@@ -73,17 +73,17 @@ TEST(PsychoacousticModelTest, BinToBarkBand_HighFreq) {
 // ---------------------------------------------------------------------------
 
 TEST(PsychoacousticModelTest, SpreadingAttenuation_Downward) {
-    // Target below masker → -10 dB/Bark: attenuation should be positive
-    // masker at 5 Bark, target at 3 Bark → dz = -2 → atten = -10 * (-2) = 20
+    // Target below masker → -25 dB/Bark: attenuation should be positive
+    // masker at 5 Bark, target at 3 Bark → dz = -2 → atten = -25 * (-2) = 50
     float atten = PsychoacousticModel::spreadingAttenuation(5.0f, 3.0f);
-    EXPECT_FLOAT_EQ(atten, 20.0f);
+    EXPECT_FLOAT_EQ(atten, 50.0f);
 }
 
 TEST(PsychoacousticModelTest, SpreadingAttenuation_Upward) {
-    // Target above masker → +25 dB/Bark
-    // masker at 3 Bark, target at 5 Bark → dz = 2 → atten = 25 * 2 = 50
+    // Target above masker → +10 dB/Bark (upward spread of masking is gentler)
+    // masker at 3 Bark, target at 5 Bark → dz = 2 → atten = 10 * 2 = 20
     float atten = PsychoacousticModel::spreadingAttenuation(3.0f, 5.0f);
-    EXPECT_FLOAT_EQ(atten, 50.0f);
+    EXPECT_FLOAT_EQ(atten, 20.0f);
 }
 
 TEST(PsychoacousticModelTest, SpreadingAttenuation_SameBand) {
@@ -94,38 +94,10 @@ TEST(PsychoacousticModelTest, SpreadingAttenuation_SameBand) {
 
 TEST(PsychoacousticModelTest, SpreadingAttenuation_Symmetric) {
     // Attenuation should be direction-dependent (not symmetric)
-    float up = PsychoacousticModel::spreadingAttenuation(3.0f, 5.0f);   // +25 * 2
-    float down = PsychoacousticModel::spreadingAttenuation(5.0f, 3.0f); // -10 * -2
+    float up = PsychoacousticModel::spreadingAttenuation(3.0f, 5.0f);   // +10 * 2
+    float down = PsychoacousticModel::spreadingAttenuation(5.0f, 3.0f); // -25 * -2
     EXPECT_NE(up, down);
-    EXPECT_GT(up, down); // upward spread attenuates more
-}
-
-// ---------------------------------------------------------------------------
-// Absolute threshold of hearing
-// ---------------------------------------------------------------------------
-
-TEST(PsychoacousticModelTest, AbsoluteThresholdDb_KnownValues) {
-    // At 1 kHz, threshold should be around 0 dB (normalized reference)
-    float thresh1k = PsychoacousticModel::absoluteThresholdDb(1000.0f);
-    EXPECT_NEAR(thresh1k, 0.0f, 5.0f);
-
-    // At 4 kHz, threshold dips (ear most sensitive ~2-5 kHz)
-    float thresh4k = PsychoacousticModel::absoluteThresholdDb(4000.0f);
-    EXPECT_LT(thresh4k, thresh1k); // more sensitive (lower threshold)
-
-    // At 100 Hz, threshold should be higher (less sensitive at low frequencies)
-    float thresh100 = PsychoacousticModel::absoluteThresholdDb(100.0f);
-    EXPECT_GT(thresh100, thresh1k); // less sensitive
-}
-
-TEST(PsychoacousticModelTest, AbsoluteThresholdDb_NonNegativeAtExtremes) {
-    // Very low frequencies should not produce NaN or negative infinity
-    float thresh20 = PsychoacousticModel::absoluteThresholdDb(20.0f);
-    EXPECT_TRUE(std::isfinite(thresh20));
-
-    // Very high frequencies should be finite
-    float thresh20k = PsychoacousticModel::absoluteThresholdDb(20000.0f);
-    EXPECT_TRUE(std::isfinite(thresh20k));
+    EXPECT_GT(down, up); // downward spread attenuates more (upward spread of masking)
 }
 
 // ---------------------------------------------------------------------------
@@ -150,7 +122,7 @@ TEST(PsychoacousticModelTest, ComputeThresholds_AllZero) {
     std::vector<float> mag(frameSize, 0.0f);
     auto thresholds = PsychoacousticModel::computeThresholds(mag, 44100, frameSize);
     EXPECT_EQ(thresholds.size(), frameSize);
-    // With zero input, thresholds should revert to absolute threshold of hearing
+    // With zero input, thresholds should revert to the minimum floor.
     // All entries should be finite and non-negative
     for (size_t i = 0; i < thresholds.size(); ++i) {
         EXPECT_TRUE(std::isfinite(thresholds[i]));
@@ -178,6 +150,34 @@ TEST(PsychoacousticModelTest, ComputeThresholds_PureTone) {
             maxThresh = t;
     }
     EXPECT_GT(maxThresh, 0.01f);
+}
+
+TEST(PsychoacousticModelTest, ComputeThresholds_WideBandNotOverAllocated) {
+    // Regression test: the top Bark band spans ~500 bins at frameSize=2048,
+    // vs. ~5 for the lowest bands. Before normalizing by bin count, summing
+    // raw energy across the whole band and reusing that sum as the per-bin
+    // threshold inflated the allowance by ~sqrt(binCount) — about 22x here —
+    // letting far more noise through per-bin than the signal justified.
+    constexpr size_t frameSize = 2048;
+    constexpr uint32_t sampleRate = 44100;
+    constexpr float kBinMag = 0.01f;
+
+    std::vector<float> mag(frameSize, 0.0f);
+    const size_t halfBins = frameSize / 2;
+    for (size_t i = 0; i <= halfBins; ++i) {
+        if (PsychoacousticModel::binToBarkBand(i, sampleRate, frameSize) ==
+            PsychoacousticModel::kNumBarkBands - 1) {
+            mag[i] = kBinMag;
+        }
+    }
+
+    auto thresholds = PsychoacousticModel::computeThresholds(mag, sampleRate, frameSize);
+    EXPECT_EQ(thresholds.size(), frameSize);
+
+    // The per-bin threshold should stay on the order of the actual per-bin
+    // magnitude present, not blow up because the band spans hundreds of bins.
+    const float threshInBand = thresholds[halfBins];
+    EXPECT_LT(threshInBand, kBinMag * 5.0f);
 }
 
 } // namespace


### PR DESCRIPTION
This pull request introduces a user-controllable masking strength parameter to the psychoacoustic masking stage, refines the psychoacoustic model to improve perceptual accuracy, and removes the absolute threshold of hearing from the masking calculation. It also updates the CLI, Node.js addon, and tests to support these changes.

**Masking Strength Parameter and Integration**
- Added a `maskingStrength` parameter to the `MaskingStage` class, CLI (`--masking-strength`), Node.js addon, and processing options, allowing users to scale the masking thresholds for more or less aggressive noise clamping. 

**Psychoacoustic Model Improvements**
- Refined the Bark-scale spreading function: upward masking slope is now 10 dB/Bark (gentler), downward is 25 dB/Bark (steeper), matching psychoacoustic literature and improving the realism of masking.
- Changed per-band energy accumulation to use average per-bin energy instead of sum, preventing excessive noise allowance in wide Bark bands, especially at high frequencies.

**Removal of Absolute Threshold of Hearing (ATH)**
- Removed the use of the absolute threshold of hearing (ATH) from the masking calculation, as its dB scale was incompatible with uncalibrated signal energies and could let noise through in quiet bands. Now, a fixed dB floor is used for minimum thresholding.

**Documentation and Usage Updates**
- Updated documentation and usage messages to reflect the new masking strength parameter and revised psychoacoustic model behavior. 
-
**Test Suite Adjustments**
- Updated all relevant tests to use the new `maskingStrength` parameter in `MaskingStage` construction and to match the revised spreading function behavior. 