### PR TITLE
fix: don't block release on Windows addon build failure

### DIFF
--- a/.github/workflows/release-addon.yml
+++ b/.github/workflows/release-addon.yml
@@ -51,6 +51,12 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         needs: addon-checks
         runs-on: ${{ matrix.runner }}
+        # TEMPORARY: windows-latest's node-gyp can't detect the Visual Studio
+        # install on that runner image (unrecognized VS version), unrelated to
+        # this project's code. Don't let that block the release job (which
+        # needs every build-addon leg to succeed) — treat Windows as
+        # best-effort until the runner/node-gyp mismatch is fixed properly.
+        continue-on-error: ${{ matrix.os == 'windows' }}
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
## Summary
- windows-latest's node-gyp fails to detect Visual Studio on that runner image (unrecognized VS version), unrelated to any code in this repo.
- Since `release` needs every `build-addon` matrix leg to succeed, this was silently blocking the whole release pipeline (no GitHub Release, no dispatch to ui) even though mac and linux builds succeeded fine.
- Marks the windows leg `continue-on-error` so mac+linux artifacts still ship. Windows will keep showing as failed (yellow warning) in the Actions UI so it isn't silently swept under the rug — this is meant as a temporary unblock, not a real fix for the underlying node-gyp/runner mismatch.

## Test plan
- [ ] Merge, then re-tag a release and confirm it completes with mac+linux artifacts and Windows shown as a non-blocking failure