### PR TITLE
fix: build Windows addon on windows-2022 to restore VS detection

### DIFF
--- a/.github/workflows/release-addon.yml
+++ b/.github/workflows/release-addon.yml
@@ -51,18 +51,16 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         needs: addon-checks
         runs-on: ${{ matrix.runner }}
-        # TEMPORARY: windows-latest's node-gyp can't detect the Visual Studio
-        # install on that runner image (unrecognized VS version), unrelated to
-        # this project's code. Don't let that block the release job (which
-        # needs every build-addon leg to succeed) — treat Windows as
-        # best-effort until the runner/node-gyp mismatch is fixed properly.
-        continue-on-error: ${{ matrix.os == 'windows' }}
         strategy:
             fail-fast: false
             matrix:
                 include:
+                    # Pinned to windows-2022 (VS 2022 / v17). windows-latest
+                    # migrated to windows-2025 (VS 18), which node-gyp 10.x
+                    # can't detect — its PowerShell VS probe both fails to
+                    # recognize the version and overflows its stdio buffer.
                     - os: windows
-                      runner: windows-latest
+                      runner: windows-2022
                       arch: x64
                     - os: linux
                       runner: ubuntu-latest


### PR DESCRIPTION
## Summary
Restores the Windows native-addon build, which was failing on `windows-latest`.

**Root cause:** `windows-latest` migrated to windows-2025, which ships Visual Studio 18 (VS 2026-era). node-gyp 10.3.1's VS finder can't handle it — the log shows both `unknown version "undefined" found at "...Visual Studio\18\Enterprise"` and a `RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]` from its PowerShell VS-detection probe. Not a code issue in this repo.

**Fix:** Pin the Windows matrix leg to `windows-2022` (VS 2022 / v17), a stable toolchain node-gyp 10.x detects reliably. Also removes the temporary `continue-on-error` added in #94, so Windows is a real gated build again rather than a silently-skippable one.

## Test plan
- [ ] `build-addon` only runs on tag/`workflow_dispatch`, so this can't run on the PR itself. After merge, validate via a `workflow_dispatch` run (or the next release tag) that the Windows leg produces `dissonance_core-win32-x64.node` and the release includes all three platform binaries.

## Follow-up (not in this PR)
- Longer term, bumping `node-gyp` to v11 would let the build track `windows-latest` again once VS 18 support matters; pinning is the lower-risk fix for now.